### PR TITLE
[가게 등록] 가게 정보 기입 완료 후 이미지가 메인 화면에 표시 안됨

### DIFF
--- a/src/page/ShopRegistration/constant/errorMessage.ts
+++ b/src/page/ShopRegistration/constant/errorMessage.ts
@@ -1,5 +1,6 @@
 export const ERRORMESSAGE = {
   image: '이미지를 등록해주세요.',
+  imageUpload: '이미지 등록에 실패했습니다. 다시 시도해주세요.',
   category: '카테고리를 선택해주세요.',
   owner: '대표자명을 입력해주세요',
   name: '가게명을 입력해주세요',

--- a/src/page/ShopRegistration/view/Mobile/Main/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/Main/index.tsx
@@ -12,7 +12,9 @@ import styles from './Main.module.scss';
 export default function Main() {
   const [isError, setIsError] = useState(false);
   const { increaseStep } = useStepStore();
-  const { imageFile, imgRef, saveImgFile } = useImageUpload();
+  const {
+    imageFile, imgRef, saveImgFile, isUploadError,
+  } = useImageUpload();
   const {
     name, setName, address, setAddress, imageUrl, setImageUrl,
   } = useShopRegistrationStore();
@@ -57,6 +59,7 @@ export default function Main() {
       </label>
       <div className={styles['form__image-error-message']}>
         {imageUrl === '' && isError && <ErrorMessage message={ERRORMESSAGE.image} />}
+        {imageUrl !== '' && isUploadError && <ErrorMessage message={ERRORMESSAGE.imageUpload} />}
       </div>
       <label
         htmlFor="name"

--- a/src/page/ShopRegistration/view/PC/index.tsx
+++ b/src/page/ShopRegistration/view/PC/index.tsx
@@ -54,7 +54,9 @@ export default function ShopRegistrationPC() {
     setTrue: openConfirmPopup,
     setFalse: closeConfirmPopup,
   } = useBooleanState(false);
-  const { imageFile, imgRef, saveImgFile } = useImageUpload();
+  const {
+    imageFile, imgRef, saveImgFile, isUploadError,
+  } = useImageUpload();
   const [isError, setIsError] = useState(false);
 
   const {
@@ -192,6 +194,7 @@ export default function ShopRegistrationPC() {
                     )}
                 </label>
                 {imageUrl === '' && isError && <ErrorMessage message={ERRORMESSAGE.image} />}
+                {imageUrl !== '' && isUploadError && <ErrorMessage message={ERRORMESSAGE.imageUpload} />}
               </div>
               <div>
                 <span className={styles.form__title}>카테고리</span>

--- a/src/utils/hooks/useImageUpload.ts
+++ b/src/utils/hooks/useImageUpload.ts
@@ -1,23 +1,35 @@
+import { uploadFile } from 'api/uploadFile/Uploadfile';
 import { useRef, useState } from 'react';
 
 export default function useImageUpload() {
   const [imageFile, setImageFile] = useState('');
+  const [isUploadError, setIsUploadError] = useState(false);
   const imgRef = useRef<HTMLInputElement>(null);
 
-  const saveImgFile = () => {
+  const saveImgFile = async () => {
     const file = imgRef.current?.files?.[0];
     const reader = new FileReader();
 
-    reader.onloadend = () => {
-      const { result } = reader;
-      if (typeof result === 'string') {
-        setImageFile(result);
-      }
-    };
     if (file) {
+      const formData = new FormData();
+      formData.append('multipartFile', file);
+      try {
+        const data = await uploadFile(formData);
+
+        if (data?.data?.file_url) {
+          setImageFile(`https://${data.data.file_url}`);
+        }
+      } catch (error) {
+        if (error) {
+          setIsUploadError(true);
+        }
+      }
+      setIsUploadError(false);
       reader.readAsDataURL(file);
     }
   };
 
-  return { imageFile, imgRef, saveImgFile };
+  return {
+    imageFile, imgRef, saveImgFile, isUploadError,
+  };
 }


### PR DESCRIPTION
## [#53] request
- 가게 정보 기입 완료 후 이미지 구현 완료
<!--
- Write here your development contents 
- e.g.) Make a main page.
-->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `deveop` branch?


### Screenshot
![image](https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/74540646/f83e4cd4-bd06-42b5-8507-1fb88d7c6083)


### Precautions (main files for this PR ...)
확인 방법
1. 본인 계정에 가게가 이미 등록 되어 있는 경우 `src/query/auth.ts`에 **32,33번 줄**안에 `/store-registration`로 수정
2. 로그인 후 가게 정보 기입
3. 메인 화면에서는 제일 첫 번째 shop이 나오기 때문에 `src/query/shop.ts`에 **21번째** 줄의 숫자를 변경해가면서 확인 가능

번거롭지만 기능이 잘 되는지 확인 부탁드립니다!