### PR TITLE
fix: 모바일뷰 취소 버튼 누르면 메인 페이지로 가도록 수정

### DIFF
--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -3,6 +3,7 @@ import useBooleanState from 'utils/hooks/useBooleanState';
 import { useState } from 'react';
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
+import { useNavigate } from 'react-router-dom';
 import MenuImage from './components/MenuImage';
 import MenuName from './components/MenuName';
 import styles from './AddMenu.module.scss';
@@ -51,6 +52,12 @@ export default function AddMenu() {
 
     addMenuMutation(newMenuData);
   };
+  const navigate = useNavigate();
+
+  const goMyShop = () => {
+    navigate('/');
+  };
+
   return (
     <div>
       {isMobile ? (
@@ -100,7 +107,7 @@ export default function AddMenu() {
                 <button
                   className={styles['mobile__button-cancel']}
                   type="button"
-                  onClick={openGoMyShopModal}
+                  onClick={goMyShop}
                 >
                   취소
                 </button>


### PR DESCRIPTION
## [Copy here issue number] request

모바일뷰에서 취소 버튼 누르면 메인 페이지로 가도록 수정했습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `deveop` branch?


### Screenshot


### Precautions (main files for this PR ...)