### PR TITLE
fix: 모바일 화면 확인 누르면 동작하도록 수정

### DIFF
--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -1,6 +1,7 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
 import MenuImage from './components/MenuImage';
@@ -15,7 +16,11 @@ import MobileDivide from './components/MobileDivide';
 export default function AddMenu() {
   const { isMobile } = useMediaQuery();
   const [isComplete, setIsComplete] = useState<boolean>(false);
+  const navigate = useNavigate();
 
+  const goMyShop = () => {
+    navigate('/');
+  };
   const toggleConfirmClick = () => {
     setIsComplete((prevState) => !prevState);
   };
@@ -50,6 +55,10 @@ export default function AddMenu() {
     };
 
     addMenuMutation(newMenuData);
+  };
+  const confirmAddMenu = () => {
+    addMenu();
+    goMyShop();
   };
   return (
     <div>
@@ -90,7 +99,7 @@ export default function AddMenu() {
                 <button
                   className={styles['mobile__button-check']}
                   type="button"
-                  onClick={openGoMyShopModal}
+                  onClick={confirmAddMenu}
                 >
                   확인
                 </button>


### PR DESCRIPTION
## [Copy here issue number] request

모발일화면에서 확인 버튼을 누르면 새로 생성한 메뉴정보를 추가하고 메인 상점 페이지로 넘어가도록 수정

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `deveop` branch?


### Screenshot


### Precautions (main files for this PR ...)