### PR TITLE
가게명이 길면 글자가 넘치는 버그 수정

### DIFF
--- a/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
+++ b/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
@@ -1,5 +1,4 @@
 .mobilestore {
-  height: 570px;
   border-bottom: 1px solid #d2dae2;
 
   &__imgs {
@@ -35,7 +34,7 @@
   &__name {
     font-weight: 500;
     font-size: 28px;
-    line-height: 15px;
+    line-height: 30px;
     align-items: center;
     color: #252525;
     margin-right: 8px;
@@ -70,7 +69,7 @@
     display: flex;
     justify-content: center;
     position: absolute;
-    width: 120px;
+    width: 110px;
     height: 40px;
     bottom: 20px;
     right: 30px;
@@ -91,7 +90,6 @@
 
 .store {
   display: flex;
-  height: 305px;
   border-bottom: 1px solid #d2dae2;
 
   &__info {
@@ -131,6 +129,26 @@
     display: flex;
     align-items: center;
     text-align: center;
+    min-width: 75px;
+
+    &--long {
+      margin-right: 8px;
+      box-sizing: border-box;
+      padding: 10px;
+      width: auto;
+      height: 24px;
+      border: 1px solid #f7941e;
+      border-radius: 13.5px;
+      color: #f7941e;
+      font-family: "Noto Sans", sans-serif;
+      font-weight: 500;
+      font-size: 12px;
+      justify-content: center;
+      display: flex;
+      align-items: center;
+      text-align: center;
+      min-width: 97px;
+    }
   }
 
   &__content {

--- a/src/page/MyShopPage/components/ShopInfo/index.tsx
+++ b/src/page/MyShopPage/components/ShopInfo/index.tsx
@@ -78,7 +78,7 @@ export default function ShopInfo({ shopInfo }: { shopInfo: MyShopInfoRes }) {
               <h1 className={styles.store__name}>{shopInfo.name}</h1>
               {shopInfo.delivery && (<div className={styles.store__keywords}>#배달 가능</div>)}
               {shopInfo.pay_card && (<div className={styles.store__keywords}>#카드 가능</div>)}
-              {shopInfo.pay_bank && (<div className={styles.store__keywords}>#계좌이체 가능</div>)}
+              {shopInfo.pay_bank && (<div className={styles['store__keywords--long']}>#계좌이체 가능</div>)}
             </div>
             <div className={styles.store__content}>
               {content.map((item) => (


### PR DESCRIPTION
## [#101 ] request

- 가게명이 길면 #배달가능 #카드가능 #계좌이체 가능 키워드가 넘치는 버그를 수정했습니다.
- 가게명이 길어도 기타정보가 다음주로 넘어가지 않도록 했습니다.
- 모바일환경에서 가게명이 길어서 다음줄로 넘어갈 때 가게명이 겹치는 버그를 수정했습니다.
- 모바일환경에서 가게 정보 수정 버튼 width를 약간 줄였습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `deveop` branch?


### Screenshot
<img width="1201" alt="스크린샷 2024-01-21 오전 1 38 01" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/a23791bd-b353-42a2-b559-9a9d0049f764">
<img width="179" alt="스크린샷 2024-01-21 오전 1 40 00" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/5ae4eec1-a1e5-44c7-8280-d42fddc89dc3">



### Precautions (main files for this PR ...)