### PR TITLE
카테고리를 미 선택한 경우에도 메뉴추가 진행이 되던 버그 수정

### DIFF
--- a/src/page/AddMenu/components/MenuCategory/MenuCategory.module.scss
+++ b/src/page/AddMenu/components/MenuCategory/MenuCategory.module.scss
@@ -140,3 +140,8 @@ $button-text-color: #252525;
     gap: 10px;
   }
 }
+
+.error-message {
+  font-size: 14px;
+  color: #f7941e;
+}

--- a/src/page/AddMenu/components/MenuCategory/index.tsx
+++ b/src/page/AddMenu/components/MenuCategory/index.tsx
@@ -139,7 +139,7 @@ export function MenuCategory({ isComplete }:MenuCategoryProps) {
           )}
         </div>
       )}
-      <span className={styles['error-message']}>{categoryError}</span>
+      {categoryError && <span className={styles['error-message']}>{categoryError}</span>}
     </div>
   );
 }

--- a/src/page/AddMenu/components/MenuCategory/index.tsx
+++ b/src/page/AddMenu/components/MenuCategory/index.tsx
@@ -4,6 +4,8 @@ import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useAddMenuStore from 'store/addMenu';
 import useMyShop from 'query/shop';
 import cn from 'utils/ts/className';
+// eslint-disable-next-line import/no-cycle
+import { useCategoryErrorStore } from 'page/AddMenu';
 import styles from './MenuCategory.module.scss';
 
 interface MenuCategory {
@@ -13,16 +15,17 @@ interface MenuCategory {
 interface MenuCategoryProps {
   isComplete: boolean;
 }
-
-export default function MenuCategory({ isComplete }:MenuCategoryProps) {
+export function MenuCategory({ isComplete }:MenuCategoryProps) {
   const { isMobile } = useMediaQuery();
   const { shopData } = useMyShop();
   const { setCategoryIds } = useAddMenuStore();
+  const { categoryError } = useCategoryErrorStore();
   const [selectedCategories, setSelectedCategories] = useState<MenuCategory[]>([]);
   const appendSelectCategory = (category: MenuCategory) => {
     const newSelected = selectedCategories.some((c) => c.id === category.id)
       ? selectedCategories.filter((c) => c.id !== category.id)
       : [...selectedCategories, category];
+
     setSelectedCategories(newSelected);
     setCategoryIds(newSelected.map((cat) => cat.id));
   };
@@ -136,6 +139,7 @@ export default function MenuCategory({ isComplete }:MenuCategoryProps) {
           )}
         </div>
       )}
+      <span className={styles['error-message']}>{categoryError}</span>
     </div>
   );
 }

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -70,7 +70,6 @@ export default function AddMenu() {
       })),
       single_price: typeof singlePrice === 'string' ? parseInt(singlePrice, 10) : singlePrice,
     };
-
     addMenuMutation(newMenuData);
   };
   const confirmAddMenu = () => {
@@ -84,6 +83,7 @@ export default function AddMenu() {
     },
     [resetCategoryIds, setCategoryError],
   );
+
   return (
     <div>
       {isMobile ? (

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -4,14 +4,25 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
+import { create } from 'zustand';
 import MenuImage from './components/MenuImage';
 import MenuName from './components/MenuName';
 import styles from './AddMenu.module.scss';
 import MenuPrice from './components/MenuPrice';
-import MenuCategory from './components/MenuCategory';
+import { MenuCategory } from './components/MenuCategory';
 import MenuDetail from './components/MenuDetail';
 import GoMyShopModal from './components/GoMyShop';
 import MobileDivide from './components/MobileDivide';
+
+interface CategoryErrorStore {
+  categoryError: string;
+  setCategoryError: (error: string) => void;
+}
+
+export const useCategoryErrorStore = create<CategoryErrorStore>((set) => ({
+  categoryError: '',
+  setCategoryError: (error) => set({ categoryError: error }),
+}));
 
 export default function AddMenu() {
   const { isMobile } = useMediaQuery();
@@ -20,9 +31,6 @@ export default function AddMenu() {
 
   const goMyShop = () => {
     navigate('/');
-  };
-  const toggleConfirmClick = () => {
-    setIsComplete((prevState) => !prevState);
   };
   const {
     value: isGoMyShopModal,
@@ -39,7 +47,15 @@ export default function AddMenu() {
     singlePrice,
   } = useAddMenuStore();
   const { addMenuMutation } = useMyShop();
-
+  const { setCategoryError } = useCategoryErrorStore();
+  const toggleConfirmClick = () => {
+    if (categoryIds.length === 0) {
+      setCategoryError('카테고리를 1개 이상 선택해주세요.');
+      return;
+    }
+    setCategoryError('');
+    setIsComplete((prevState) => !prevState);
+  };
   const addMenu = () => {
     const newMenuData = {
       category_ids: categoryIds,

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -9,6 +9,7 @@ import MenuImage from './components/MenuImage';
 import MenuName from './components/MenuName';
 import styles from './AddMenu.module.scss';
 import MenuPrice from './components/MenuPrice';
+// eslint-disable-next-line import/no-cycle
 import { MenuCategory } from './components/MenuCategory';
 import MenuDetail from './components/MenuDetail';
 import GoMyShopModal from './components/GoMyShop';
@@ -28,8 +29,9 @@ export default function AddMenu() {
   const { isMobile } = useMediaQuery();
   const [isComplete, setIsComplete] = useState<boolean>(false);
   const navigate = useNavigate();
-
+  const { resetCategoryIds } = useAddMenuStore();
   const goMyShop = () => {
+    resetCategoryIds();
     navigate('/');
   };
   const {

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -1,6 +1,6 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useBooleanState from 'utils/hooks/useBooleanState';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
@@ -30,8 +30,8 @@ export default function AddMenu() {
   const [isComplete, setIsComplete] = useState<boolean>(false);
   const navigate = useNavigate();
   const { resetCategoryIds } = useAddMenuStore();
+  const { setCategoryError } = useCategoryErrorStore();
   const goMyShop = () => {
-    resetCategoryIds();
     navigate('/');
   };
   const {
@@ -49,7 +49,6 @@ export default function AddMenu() {
     singlePrice,
   } = useAddMenuStore();
   const { addMenuMutation } = useMyShop();
-  const { setCategoryError } = useCategoryErrorStore();
   const toggleConfirmClick = () => {
     if (categoryIds.length === 0) {
       setCategoryError('카테고리를 1개 이상 선택해주세요.');
@@ -78,6 +77,13 @@ export default function AddMenu() {
     addMenu();
     goMyShop();
   };
+  useEffect(
+    () => {
+      resetCategoryIds();
+      setCategoryError('');
+    },
+    [resetCategoryIds, setCategoryError],
+  );
   return (
     <div>
       {isMobile ? (

--- a/src/store/addMenu.ts
+++ b/src/store/addMenu.ts
@@ -24,6 +24,7 @@ interface AddMenuStore {
   setSinglePrice: (singlePrice: number) => void;
   resetOptionPrice: () => void;
   resetAddMenuStore: () => void;
+  resetCategoryIds: () => void;
 }
 
 const useAddMenuStore = create<AddMenuStore>((set) => ({
@@ -56,6 +57,7 @@ const useAddMenuStore = create<AddMenuStore>((set) => ({
     optionPrices: [{ id: 0, option: '', price: 0 }],
     singlePrice: 0,
   }),
+  resetCategoryIds: () => set({ categoryIds: [] }),
 }));
 
 export default useAddMenuStore;


### PR DESCRIPTION
## [#104 ] request

- 서버측 에러 메시지를 이용하여 에러핸들링을 하고 싶었지만 다음과 같은 문제가 있었습니다.
<img width="50%" alt="image" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/1a11d0a4-c1b9-47c6-9f5a-feebd49f3e3a">

내 상점으로 이동하면서 서버측에 post 요청을 보내게 되고 에러메시지를 반환 받는거라, 메뉴추가가 되었다는 메시지가 발생하고 에러메시지를 띄울 수 있게 되는데, 이는 적절치 못한 에러 핸들링이라고 생각했습니다.
따라서 메뉴추가 화면에서 확인버튼을 누르기 전에 에러핸들링이 필요하다고 판단했습니다.

- 카테고리가 선택되지 않으면 ```카테고리를 1개 이상 선택해주세요```에러 메시지를 하단에 띄웁니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `deveop` branch?


### Screenshot
<img width="1691" alt="스크린샷 2024-01-22 오전 4 31 55" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/7160e818-c7d2-44b4-92e0-8a6332cf97b2">


### Precautions (main files for this PR ...)