### PR TITLE
메뉴추가시 메뉴명을 필수적으로 입력하도록 수정

### DIFF
--- a/src/page/AddMenu/components/MenuCategory/index.tsx
+++ b/src/page/AddMenu/components/MenuCategory/index.tsx
@@ -4,8 +4,7 @@ import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useAddMenuStore from 'store/addMenu';
 import useMyShop from 'query/shop';
 import cn from 'utils/ts/className';
-// eslint-disable-next-line import/no-cycle
-import { useCategoryErrorStore } from 'page/AddMenu';
+import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
 import styles from './MenuCategory.module.scss';
 
 interface MenuCategory {
@@ -19,7 +18,7 @@ export function MenuCategory({ isComplete }:MenuCategoryProps) {
   const { isMobile } = useMediaQuery();
   const { shopData } = useMyShop();
   const { setCategoryIds } = useAddMenuStore();
-  const { categoryError } = useCategoryErrorStore();
+  const { categoryError } = useErrorMessageStore();
   const [selectedCategories, setSelectedCategories] = useState<MenuCategory[]>([]);
   const appendSelectCategory = (category: MenuCategory) => {
     const newSelected = selectedCategories.some((c) => c.id === category.id)

--- a/src/page/AddMenu/components/MenuName/MenuName.module.scss
+++ b/src/page/AddMenu/components/MenuName/MenuName.module.scss
@@ -72,3 +72,8 @@
   font-size: 20px;
   font-weight: 500;
 }
+
+.error-message {
+  font-size: 14px;
+  color: #f7941e;
+}

--- a/src/page/AddMenu/components/MenuName/index.tsx
+++ b/src/page/AddMenu/components/MenuName/index.tsx
@@ -1,5 +1,6 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useAddMenuStore from 'store/addMenu';
+import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
 import styles from './MenuName.module.scss';
 
 interface MenuNameProps {
@@ -9,9 +10,11 @@ interface MenuNameProps {
 export default function MenuName({ isComplete }: MenuNameProps) {
   const { isMobile } = useMediaQuery();
   const { name, setName } = useAddMenuStore();
+  const { menuError } = useErrorMessageStore();
   const handleNameChange = (e : React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
   };
+
   return (
     <div>
       {isMobile ? (
@@ -45,6 +48,7 @@ export default function MenuName({ isComplete }: MenuNameProps) {
               value={name}
             />
           )}
+          {menuError && <span className={styles['error-message']}>{menuError}</span>}
         </div>
       )}
     </div>

--- a/src/page/AddMenu/hook/useFormValidation.ts
+++ b/src/page/AddMenu/hook/useFormValidation.ts
@@ -1,0 +1,31 @@
+import useAddMenuStore from 'store/addMenu';
+import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
+
+const useFormValidation = () => {
+  const { setMenuError, setCategoryError } = useErrorMessageStore();
+  const { name, categoryIds } = useAddMenuStore();
+
+  const validateFields = () => {
+    let isValid = true;
+
+    if (name.length === 0) {
+      setMenuError('메뉴명을 입력해주세요.');
+      isValid = false;
+    } else {
+      setMenuError('');
+    }
+
+    if (categoryIds.length === 0) {
+      setCategoryError('카테고리를 1개 이상 선택해주세요.');
+      isValid = false;
+    } else {
+      setCategoryError('');
+    }
+
+    return isValid;
+  };
+
+  return { validateFields };
+};
+
+export default useFormValidation;

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -13,6 +13,7 @@ import { MenuCategory } from './components/MenuCategory';
 import MenuDetail from './components/MenuDetail';
 import GoMyShopModal from './components/GoMyShop';
 import MobileDivide from './components/MobileDivide';
+import useFormValidation from './hook/useFormValidation';
 
 export default function AddMenu() {
   const { isMobile } = useMediaQuery();
@@ -38,18 +39,11 @@ export default function AddMenu() {
     singlePrice,
   } = useAddMenuStore();
   const { addMenuMutation } = useMyShop();
+  const { validateFields } = useFormValidation();
   const toggleConfirmClick = () => {
-    if (name.length === 0) {
-      setMenuError('메뉴명을 입력해주세요.');
-      return;
+    if (validateFields()) {
+      setIsComplete((prevState) => !prevState);
     }
-    if (categoryIds.length === 0) {
-      setCategoryError('카테고리를 1개 이상 선택해주세요.');
-      return;
-    }
-    setMenuError('');
-    setCategoryError('');
-    setIsComplete((prevState) => !prevState);
   };
   const addMenu = () => {
     const newMenuData = {

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -4,33 +4,22 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
-import { create } from 'zustand';
+import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
 import MenuImage from './components/MenuImage';
 import MenuName from './components/MenuName';
 import styles from './AddMenu.module.scss';
 import MenuPrice from './components/MenuPrice';
-// eslint-disable-next-line import/no-cycle
 import { MenuCategory } from './components/MenuCategory';
 import MenuDetail from './components/MenuDetail';
 import GoMyShopModal from './components/GoMyShop';
 import MobileDivide from './components/MobileDivide';
 
-interface CategoryErrorStore {
-  categoryError: string;
-  setCategoryError: (error: string) => void;
-}
-
-export const useCategoryErrorStore = create<CategoryErrorStore>((set) => ({
-  categoryError: '',
-  setCategoryError: (error) => set({ categoryError: error }),
-}));
-
 export default function AddMenu() {
   const { isMobile } = useMediaQuery();
   const [isComplete, setIsComplete] = useState<boolean>(false);
   const navigate = useNavigate();
-  const { resetCategoryIds } = useAddMenuStore();
-  const { setCategoryError } = useCategoryErrorStore();
+  const { resetMenuName, resetCategoryIds } = useAddMenuStore();
+  const { setMenuError, setCategoryError } = useErrorMessageStore();
   const goMyShop = () => {
     navigate('/');
   };
@@ -50,10 +39,15 @@ export default function AddMenu() {
   } = useAddMenuStore();
   const { addMenuMutation } = useMyShop();
   const toggleConfirmClick = () => {
+    if (name.length === 0) {
+      setMenuError('메뉴명을 입력해주세요.');
+      return;
+    }
     if (categoryIds.length === 0) {
       setCategoryError('카테고리를 1개 이상 선택해주세요.');
       return;
     }
+    setMenuError('');
     setCategoryError('');
     setIsComplete((prevState) => !prevState);
   };
@@ -78,10 +72,12 @@ export default function AddMenu() {
   };
   useEffect(
     () => {
+      resetMenuName();
       resetCategoryIds();
+      setMenuError('');
       setCategoryError('');
     },
-    [resetCategoryIds, setCategoryError],
+    [resetMenuName, setMenuError, resetCategoryIds, setCategoryError],
   );
 
   return (

--- a/src/store/addMenu.ts
+++ b/src/store/addMenu.ts
@@ -25,6 +25,7 @@ interface AddMenuStore {
   resetOptionPrice: () => void;
   resetAddMenuStore: () => void;
   resetCategoryIds: () => void;
+  resetMenuName: () => void;
 }
 
 const useAddMenuStore = create<AddMenuStore>((set) => ({
@@ -58,6 +59,7 @@ const useAddMenuStore = create<AddMenuStore>((set) => ({
     singlePrice: 0,
   }),
   resetCategoryIds: () => set({ categoryIds: [] }),
+  resetMenuName: () => set({ name: '' }),
 }));
 
 export default useAddMenuStore;

--- a/src/store/addMenuErrorMessageStore.ts
+++ b/src/store/addMenuErrorMessageStore.ts
@@ -1,0 +1,15 @@
+import create from 'zustand';
+
+interface ErrorMessageStore {
+  menuError: string;
+  setMenuError: (error: string) => void;
+  categoryError: string;
+  setCategoryError: (error: string) => void;
+}
+
+export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
+  menuError: '',
+  setMenuError: (error) => set({ menuError: error }),
+  categoryError: '',
+  setCategoryError: (error) => set({ categoryError: error }),
+}));

--- a/src/store/addMenuErrorMessageStore.ts
+++ b/src/store/addMenuErrorMessageStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 
 interface ErrorMessageStore {
   menuError: string;


### PR DESCRIPTION
## [#107 ] request

- 메뉴추가시 메뉴명 입력이 필수이지만 공백으로 메뉴추가를 하여도 메뉴추가가 진행되던 버그를 수정했습니다.
이슈와 다르게 가격정보의 경우 서버측에서 입력을 필수로 하고있지 않아, 메뉴명만 필수적으로 입력하도록 하였습니다.
가격에서 사이즈의 경우 입력하지 않을경우 메뉴명이 들어가며, 가격의 경우 입력하지 않을경우 0원이 들어갑니다.

- 추가적으로 순환구조로 인해 발생하던 eslint 에러를 해결하기 위해 순환로직을 분리하여 별도의 파일로 만들었습니다.
이외에도 방대해지는 로직의 경우 별도의 Hook으로 분리했습니다.


## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot
<img width="1226" alt="스크린샷 2024-01-24 오전 1 29 58" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/ec352a01-8bb5-44bd-859a-a6df4cdef0c0">


### Precautions (main files for this PR ...)

Close #107 
