### PR TITLE
상점 등록을 하지 않아도 메뉴 추가로직이 실행되는 버그 수정

### DIFF
--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -1,6 +1,7 @@
 import useMyShop from 'query/shop';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import CatagoryMenuList from './components/CatagoryMenuList';
 import StoreInfo from './components/ShopInfo';
 import styles from './MyShopPage.module.scss';
@@ -8,6 +9,13 @@ import styles from './MyShopPage.module.scss';
 export default function MyShopPage() {
   const { isMobile } = useMediaQuery();
   const { shopData, menuData } = useMyShop();
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (!shopData) {
+      navigate('/store-registration');
+    }
+  }, [shopData, navigate]);
+
   return (
     <div>
       {isMobile ? (

--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -2,19 +2,31 @@ import useMyShop from 'query/shop';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
+import { getMe } from 'api/auth';
 import CatagoryMenuList from './components/CatagoryMenuList';
 import StoreInfo from './components/ShopInfo';
 import styles from './MyShopPage.module.scss';
 
 export default function MyShopPage() {
   const { isMobile } = useMediaQuery();
-  const { shopData, menuData } = useMyShop();
+  const {
+    shopData, menuData,
+  } = useMyShop();
   const navigate = useNavigate();
+  const shopCount = async function getShopCount() {
+    const res = await getMe();
+    const shopsCount = res.shops.length;
+    return shopsCount;
+  };
+
   useEffect(() => {
-    if (!shopData) {
-      navigate('/store-registration');
-    }
-  }, [shopData, navigate]);
+    (async () => {
+      const count = await shopCount();
+      if (count === 0) {
+        navigate('/store-registration');
+      }
+    })();
+  }, [navigate]);
 
   return (
     <div>

--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-alert */
+/* eslint-disable consistent-return */
 import useMyShop from 'query/shop';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import { Link, useNavigate } from 'react-router-dom';
@@ -13,13 +15,18 @@ export default function MyShopPage() {
     shopData, menuData,
   } = useMyShop();
   const navigate = useNavigate();
-  const shopCount = async function getShopCount() {
-    const res = await getMe();
-    const shopsCount = res.shops.length;
-    return shopsCount;
-  };
 
   useEffect(() => {
+    const shopCount = async function getShopCount() {
+      try {
+        const res = await getMe();
+        const shopsCount = res.shops.length;
+        return shopsCount;
+      } catch (error) {
+        alert('내정보를 불러오는데 실패했습니다.');
+        navigate('/login');
+      }
+    };
     (async () => {
       const count = await shopCount();
       if (count === 0) {


### PR DESCRIPTION
## [#109 ] request

- 기존에는 가게 정보 기입 과정에서 주소창을 루트`/`로 수정하거나, 특수한 경우에 가게정보 페이지로 이동할 수 있는 버그가 있었습니다.
가게정보 페이지에서 가게정보가 없을 시 강제로 가게정보기입 페이지로 이동시키는 로직을 추가했습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot
<img width="938" alt="image" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/4974bf3c-d045-408c-8d13-caa483024aff">


### Precautions (main files for this PR ...)

Close #109 
