### PR TITLE
상점등록을 하지 않아도 가게정보로 이동가능한 버그 수정 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,29 +11,32 @@ import MyStorePage from 'page/MyShopPage';
 import ShopRegistration from 'page/ShopRegistration';
 import AddMenu from 'page/AddMenu';
 import PageNotFound from 'page/Error/PageNotFound';
+import { Suspense } from 'react';
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<DefaultLayout />}>
-        <Route path="/" element={<MyStorePage />} />
-        <Route path="/store-registration" element={<ShopRegistration />} />
-        <Route path="/add-menu" element={<AddMenu />} />
-        <Route path="/modify-info" element={<PageNotFound />} />
-        <Route path="/store-info" element={<PageNotFound />} />
-        <Route path="/menu-management" element={<PageNotFound />} />
-        <Route path="/order-management" element={<PageNotFound />} />
-        <Route path="/sales-management" element={<PageNotFound />} />
-        <Route path="/shop-add" element={<PageNotFound />} />
-      </Route>
-      <Route element={<AuthLayout />}>
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/find-password" element={<FindPassword />} />
-        <Route path="/new-password" element={<NewPassword />} />
-        <Route path="/complete-change-password" element={<CompleteChangePassword />} />
-      </Route>
-    </Routes>
+    <Suspense fallback={<div />}>
+      <Routes>
+        <Route path="/" element={<DefaultLayout />}>
+          <Route path="/" element={<MyStorePage />} />
+          <Route path="/store-registration" element={<ShopRegistration />} />
+          <Route path="/add-menu" element={<AddMenu />} />
+          <Route path="/modify-info" element={<PageNotFound />} />
+          <Route path="/store-info" element={<PageNotFound />} />
+          <Route path="/menu-management" element={<PageNotFound />} />
+          <Route path="/order-management" element={<PageNotFound />} />
+          <Route path="/sales-management" element={<PageNotFound />} />
+          <Route path="/shop-add" element={<PageNotFound />} />
+        </Route>
+        <Route element={<AuthLayout />}>
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/find-password" element={<FindPassword />} />
+          <Route path="/new-password" element={<NewPassword />} />
+          <Route path="/complete-change-password" element={<CompleteChangePassword />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 }
 

--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -4,7 +4,6 @@ import useMyShop from 'query/shop';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
-import { getMe } from 'api/auth';
 import CatagoryMenuList from './components/CatagoryMenuList';
 import StoreInfo from './components/ShopInfo';
 import styles from './MyShopPage.module.scss';
@@ -12,28 +11,18 @@ import styles from './MyShopPage.module.scss';
 export default function MyShopPage() {
   const { isMobile } = useMediaQuery();
   const {
-    shopData, menuData,
+    shopData, menuData, isLoading,
   } = useMyShop();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const shopCount = async function getShopCount() {
-      try {
-        const res = await getMe();
-        const shopsCount = res.shops.length;
-        return shopsCount;
-      } catch (error) {
-        alert('내정보를 불러오는데 실패했습니다.');
-        navigate('/login');
-      }
-    };
-    (async () => {
-      const count = await shopCount();
-      if (count === 0) {
+  useEffect(
+    () => {
+      if (!shopData && !isLoading) {
         navigate('/store-registration');
       }
-    })();
-  }, [navigate]);
+    },
+    [shopData, navigate, isLoading],
+  );
 
   return (
     <div>

--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-alert */
-/* eslint-disable consistent-return */
 import useMyShop from 'query/shop';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import { Link, useNavigate } from 'react-router-dom';

--- a/src/query/shop.ts
+++ b/src/query/shop.ts
@@ -1,4 +1,6 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useMutation, useQuery, useQueryClient, useSuspenseQuery,
+} from '@tanstack/react-query';
 import {
   getMyShopList, getShopInfo, getMenuInfoList, addMenu,
 } from 'api/shop';
@@ -10,27 +12,22 @@ const useMyShop = () => {
   const myShopQueryKey = useUserStore.getState().user?.company_number;
   const queryClient = useQueryClient();
   const { resetAddMenuStore } = useAddMenuStore();
-  const { data: myShop } = useQuery({
+  const { data: myShop } = useSuspenseQuery({
     queryKey: ['myShop', myShopQueryKey],
     queryFn: () => getMyShopList(),
   });
 
-  const selectedShopId = (idx:number) => {
-    if (myShop?.shops.length === 0) return null;
-    return myShop?.shops[idx].id;
-  }; // shops가 있을때 인자로 가진 인덱스의 가게 id를 리턴
+  const shopId = myShop.shops[0]?.id;
 
-  const shopId = selectedShopId(0);
-
-  const { data: shopData } = useQuery({
+  const { data: shopData, isLoading } = useQuery({
     queryKey: ['myShopInfo', shopId],
-    queryFn: () => getShopInfo({ id: shopId! }),
+    queryFn: () => getShopInfo({ id: shopId }),
     enabled: !!shopId,
   });
 
   const { data: menuData } = useQuery({
     queryKey: ['myMenuInfo', shopId],
-    queryFn: () => getMenuInfoList({ id: shopId! }),
+    queryFn: () => getMenuInfoList({ id: shopId }),
     enabled: !!shopId,
   });
 
@@ -48,7 +45,7 @@ const useMyShop = () => {
   });
 
   return {
-    shopData, menuData, addMenuMutation, addMenuError,
+    shopData, menuData, addMenuMutation, addMenuError, isLoading,
   };
 };
 


### PR DESCRIPTION
## [#112 ] request

이전 #110 의 문제를 해결했습니다.
> shopData를 이용하여 기능을 구현하려고 시도했으나, 해당 응답에서 가게정보가 있을 때도 undefined를 응답으로 받고 정상적인 가게정보를 응답으로 받아 가게정보가 있는경우와 없는 경우를 구분할 수 없었습니다.
정상적인 API호출 시에도 undefined가 수신되는 문제는 비동기처리 문제로 추정되나, 도저히 구체적인 원인을 찾을 수가 없어, getMe에서 가게 갯수를 응답으로 받아 해당기능을 구현했습니다.

데이터가 있음에도 undefined가 발생한 이유는 react-query의 경우 로딩중일 때 데이터가 undefined가 됩니다.
이를 방지하기 위해 `!shopData && !isLoading`을 사용했음에도 `{shopData} = useQuery()` 의 `enabled: !!shopId` 에서 shopId의 데이터를 기다리는 동안 isLoading이 false가 되어 `!shopData && !isLoading` 조건이 만족되어버리는 문제가 있었습니다.
즉, `shopData`가 없어서 undefined인 경우와 로딩중이여서 undefined인 경우를 구분하기가 어려운 문제가 있었습니다.
로딩중일 때 undefined인 경우를 해결하기 위해 `myShop()`을 호출할 때 `useSuspenseQuery`를 사용하여 API호출이 끝나야 데이터를 가지도록 수정하였습니다.
결론적으로 `shopData`가 없는 경우에만 undefined가 발생하도록 하여 `shopData`로 에러핸들링을 하도록 하였습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot

### Precautions (main files for this PR ...)

Close #112 
