### PR TITLE
로그인시 상황에 맞는 에러메시지가 표시되도록 수정

### DIFF
--- a/src/model/auth/index.ts
+++ b/src/model/auth/index.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
 export const LoginParams = z.object({
-  email: z.string().email(),
+  email: z.string().email({ message: '이메일 형식이 아닙니다.' }),
   password: z.string(),
 });
 

--- a/src/page/AddMenu/components/MenuCategory/index.tsx
+++ b/src/page/AddMenu/components/MenuCategory/index.tsx
@@ -4,7 +4,7 @@ import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useAddMenuStore from 'store/addMenu';
 import useMyShop from 'query/shop';
 import cn from 'utils/ts/className';
-import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
+import { useErrorMessageStore } from 'store/errorMessageStore';
 import styles from './MenuCategory.module.scss';
 
 interface MenuCategory {

--- a/src/page/AddMenu/components/MenuName/index.tsx
+++ b/src/page/AddMenu/components/MenuName/index.tsx
@@ -1,6 +1,6 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useAddMenuStore from 'store/addMenu';
-import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
+import { useErrorMessageStore } from 'store/errorMessageStore';
 import styles from './MenuName.module.scss';
 
 interface MenuNameProps {

--- a/src/page/AddMenu/hook/useFormValidation.ts
+++ b/src/page/AddMenu/hook/useFormValidation.ts
@@ -1,5 +1,5 @@
 import useAddMenuStore from 'store/addMenu';
-import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
+import { useErrorMessageStore } from 'store/errorMessageStore';
 
 const useFormValidation = () => {
   const { setMenuError, setCategoryError } = useErrorMessageStore();

--- a/src/page/AddMenu/index.tsx
+++ b/src/page/AddMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
-import { useErrorMessageStore } from 'store/addMenuErrorMessageStore';
+import { useErrorMessageStore } from 'store/errorMessageStore';
 import MenuImage from './components/MenuImage';
 import MenuName from './components/MenuName';
 import styles from './AddMenu.module.scss';

--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -23,7 +23,7 @@ export default function Login() {
   const { login, isError: isServerError } = useLogin();
   const [isFormError, setIsFormError] = useState(false);
   const navigate = useNavigate();
-  const { loginError } = useErrorMessageStore();
+  const { loginError, emailError, setEmailError } = useErrorMessageStore();
 
   const isError = isServerError || isFormError;
 
@@ -39,8 +39,11 @@ export default function Login() {
     login({ email: data.email, password: hashedPassword, isAutoLogin });
   };
 
-  const onError = () => {
+  const onError = (error: any) => {
     setIsFormError(true);
+    if (error.email) {
+      setEmailError(error.email.message);
+    }
   };
 
   return (
@@ -79,7 +82,7 @@ export default function Login() {
           </div>
           <div className={styles['form__auto-login']}>
             {(isError || !!isFormError) && (
-            <div className={styles['form__error-message']}>{loginError}</div>
+            <div className={styles['form__error-message']}>{loginError || emailError}</div>
             )}
             <label className={styles['form__auto-login__label']} htmlFor="auto-login">
               <input

--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { LoginParams } from 'model/auth';
 import { useState } from 'react';
 import sha256 from 'utils/ts/SHA-256';
+import { useErrorMessageStore } from 'store/errorMessageStore';
 import styles from './Login.module.scss';
 import OPTION from './static/option';
 
@@ -22,6 +23,7 @@ export default function Login() {
   const { login, isError: isServerError } = useLogin();
   const [isFormError, setIsFormError] = useState(false);
   const navigate = useNavigate();
+  const { loginError } = useErrorMessageStore();
 
   const isError = isServerError || isFormError;
 
@@ -77,7 +79,7 @@ export default function Login() {
           </div>
           <div className={styles['form__auto-login']}>
             {(isError || !!isFormError) && (
-            <div className={styles['form__error-message']}>아이디 또는 비밀번호를 잘못 입력했습니다</div>
+            <div className={styles['form__error-message']}>{loginError}</div>
             )}
             <label className={styles['form__auto-login__label']} htmlFor="auto-login">
               <input

--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -23,7 +23,8 @@ export default function Login() {
   const { login, isError: isServerError } = useLogin();
   const [isFormError, setIsFormError] = useState(false);
   const navigate = useNavigate();
-  const { loginError, emailError, setEmailError } = useErrorMessageStore();
+  const { loginError } = useErrorMessageStore();
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   const isError = isServerError || isFormError;
 

--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as ShowIcon } from 'assets/svg/auth/show.svg';
 import { ReactComponent as BlindIcon } from 'assets/svg/auth/blind.svg';
 import { ReactComponent as LockIcon } from 'assets/svg/auth/lock.svg';
 import { useLogin } from 'query/auth';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import { FieldErrors, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { LoginParams } from 'model/auth';
 import { useState } from 'react';
@@ -40,10 +40,10 @@ export default function Login() {
     login({ email: data.email, password: hashedPassword, isAutoLogin });
   };
 
-  const onError = (error: any) => {
+  const onError = (error: FieldErrors<LoginParams>) => {
     setIsFormError(true);
     if (error.email) {
-      setEmailError(error.email.message);
+      setEmailError(error.email.message ?? null);
     }
   };
 

--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -24,7 +24,7 @@ export default function Login() {
   const [isFormError, setIsFormError] = useState(false);
   const navigate = useNavigate();
   const { loginError } = useErrorMessageStore();
-  const [emailError, setEmailError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState('');
 
   const isError = isServerError || isFormError;
 
@@ -43,7 +43,7 @@ export default function Login() {
   const onError = (error: FieldErrors<LoginParams>) => {
     setIsFormError(true);
     if (error.email) {
-      setEmailError(error.email.message ?? null);
+      setEmailError(error.email?.message || '');
     }
   };
 

--- a/src/query/auth.ts
+++ b/src/query/auth.ts
@@ -7,6 +7,7 @@ import axios, { AxiosError } from 'axios';
 import { LoginForm } from 'model/auth';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useErrorMessageStore } from 'store/errorMessageStore';
 import usePrevPathStore from 'store/path';
 
 interface VerifyInput {
@@ -32,6 +33,7 @@ interface ErrorResponse {
 export const useLogin = () => {
   const navigate = useNavigate();
   const { setPrevPath } = usePrevPathStore((state) => state);
+  const { setLoginError } = useErrorMessageStore();
 
   const { mutate, error, isError } = useMutation({
     mutationFn: (variables: LoginForm) => postLogin({
@@ -52,9 +54,10 @@ export const useLogin = () => {
         navigate('/store-registration');
       }
     },
-    onError: () => {
+    onError: (err: AxiosError<ErrorResponse>) => {
       sessionStorage.removeItem('access_token');
       localStorage.removeItem('refresh_token');
+      setLoginError(err.response?.data.message || err.message);
     },
   });
 

--- a/src/store/errorMessageStore.ts
+++ b/src/store/errorMessageStore.ts
@@ -7,8 +7,6 @@ interface ErrorMessageStore {
   setCategoryError: (error: string) => void;
   loginError: string;
   setLoginError: (error: string) => void;
-  emailError: string;
-  setEmailError: (error: string) => void;
 }
 
 export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
@@ -18,6 +16,4 @@ export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
   setCategoryError: (error) => set({ categoryError: error }),
   loginError: '',
   setLoginError: (error) => set({ loginError: error }),
-  emailError: '',
-  setEmailError: (error) => set({ emailError: error }),
 }));

--- a/src/store/errorMessageStore.ts
+++ b/src/store/errorMessageStore.ts
@@ -5,6 +5,8 @@ interface ErrorMessageStore {
   setMenuError: (error: string) => void;
   categoryError: string;
   setCategoryError: (error: string) => void;
+  loginError: string;
+  setLoginError: (error: string) => void;
 }
 
 export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
@@ -12,4 +14,6 @@ export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
   setMenuError: (error) => set({ menuError: error }),
   categoryError: '',
   setCategoryError: (error) => set({ categoryError: error }),
+  loginError: '',
+  setLoginError: (error) => set({ loginError: error }),
 }));

--- a/src/store/errorMessageStore.ts
+++ b/src/store/errorMessageStore.ts
@@ -7,6 +7,8 @@ interface ErrorMessageStore {
   setCategoryError: (error: string) => void;
   loginError: string;
   setLoginError: (error: string) => void;
+  emailError: string;
+  setEmailError: (error: string) => void;
 }
 
 export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
@@ -16,4 +18,6 @@ export const useErrorMessageStore = create<ErrorMessageStore>((set) => ({
   setCategoryError: (error) => set({ categoryError: error }),
   loginError: '',
   setLoginError: (error) => set({ loginError: error }),
+  emailError: '',
+  setEmailError: (error) => set({ emailError: error }),
 }));


### PR DESCRIPTION
## [#115 ] request

로그인시 발생할 수 있는 다양한 에러상황에 따라 적절한 에러메시지가 출력되도록 수정하였습니다.
기존에는 일괄적으로 `아이디 또는 비밀번호를 잘못 입력했습니다`가 출력되었으나, 다양한 에러상황이 존재하여, 서버에서 제공하는 에러메시지를 출력하도록 하였습니다.

가입승인이 되지않은 경우 - 권한이 없습니다.
비밀번호가 일치하지 않는 경우 - 비밀번호가 일치하지 않습니다.
아이디가 일치하지 않는 경우 - 회원이 존재하지 않습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot
**수정 이전**
![image](https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/ef60ab82-2570-413c-981a-86ea52553957)

---
**수정 이후**

<img width="49%" alt="스크린샷 2024-01-31 오전 3 49 56" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/b1bd33cf-840f-4a85-b2e7-431108a438ca">
<img width="49%" alt="스크린샷 2024-01-31 오전 3 50 02" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/29d606fa-b4be-4308-b3ec-49bf06eb03b2">
<img width="49%" alt="스크린샷 2024-01-31 오전 3 50 07" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/51679514-2a0e-434f-a078-2fbe81ce8a6c">


### Precautions (main files for this PR ...)

Close #115 
