### PR TITLE
fix: "/" 페이지로 이동시 모든 메뉴 데이터 초기화 되도록 수정

### DIFF
--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -1,7 +1,7 @@
 import useMyShop from 'query/shop';
 import useAddMenuStore from 'store/addMenu';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import { useEffect } from 'react';
 import CatagoryMenuList from './components/CatagoryMenuList';
@@ -11,16 +11,13 @@ import EditShopInfoModal from './components/EditShopInfoModal';
 
 export default function MyShopPage() {
   const { isMobile } = useMediaQuery();
-  const location = useLocation();
   const {
     shopData, menusData, refetchShopData, isLoading,
   } = useMyShop();
   const { resetAddMenuStore } = useAddMenuStore();
   useEffect(() => {
-    if (location.pathname === '/') {
-      resetAddMenuStore();
-    }
-  }, [location, resetAddMenuStore]);
+    resetAddMenuStore();
+  }, [resetAddMenuStore]);
   const navigate = useNavigate();
   const {
     setTrue: openEditShopInfoModal,

--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -1,6 +1,7 @@
 import useMyShop from 'query/shop';
+import useAddMenuStore from 'store/addMenu';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import { useEffect } from 'react';
 import CatagoryMenuList from './components/CatagoryMenuList';
@@ -10,9 +11,16 @@ import EditShopInfoModal from './components/EditShopInfoModal';
 
 export default function MyShopPage() {
   const { isMobile } = useMediaQuery();
+  const location = useLocation();
   const {
     shopData, menusData, refetchShopData, isLoading,
   } = useMyShop();
+  const { resetAddMenuStore } = useAddMenuStore();
+  useEffect(() => {
+    if (location.pathname === '/') {
+      resetAddMenuStore();
+    }
+  }, [location, resetAddMenuStore]);
   const navigate = useNavigate();
   const {
     setTrue: openEditShopInfoModal,


### PR DESCRIPTION
## [#123] request


- "/"페이지로 이동 시 모든 메뉴 데이터 초기화 되도록 하여 뒤로가기나 코인 로고 클릭으로 메인 페이지 이동시 전역 데이터 초기화를 하도록 하였습니다.


## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot

### Precautions (main files for this PR ...)

Close #123 
