### PR TITLE
가게 정보 수정 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-hook-form": "^7.43.9",
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.4",
     "sass": "^1.60.0",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import AddMenu from 'page/AddMenu';
 import PageNotFound from 'page/Error/PageNotFound';
 import ModifyMenu from 'page/ModifyMenu';
 import { Suspense } from 'react';
+import Toast from 'component/common/Toast';
 
 function App() {
   return (
@@ -37,6 +38,7 @@ function App() {
           <Route path="/complete-change-password" element={<CompleteChangePassword />} />
         </Route>
       </Routes>
+      <Toast />
     </Suspense>
   );
 }

--- a/src/component/common/Toast/index.tsx
+++ b/src/component/common/Toast/index.tsx
@@ -1,0 +1,8 @@
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.min.css';
+
+export default function Toast() {
+  return (
+    <ToastContainer />
+  );
+}

--- a/src/page/MyShopPage/components/EditShopInfoModal/EditShopInfoModal.module.scss
+++ b/src/page/MyShopPage/components/EditShopInfoModal/EditShopInfoModal.module.scss
@@ -75,14 +75,17 @@
   margin-right: 16px;
 
   &__image {
+    object-fit: contain;
     width: 224px;
     height: 136px;
+    box-shadow: 0 0 1px 0 #00000080;
+    margin-left: 1px;
   }
 
   &__delete-button {
     position: absolute;
-    top: -5px;
-    right: -5px;
+    top: -7px;
+    right: -7px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -212,11 +215,13 @@
 
   &__image-content {
     position: relative;
-    min-width: 360px;
+    min-width: 328px;
     height: 255px;
+    box-shadow: 0 0 1px 0 #00000080;
   }
 
   &__main-image {
+    object-fit: contain;
     width: 100%;
     height: 100%;
   }

--- a/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
+++ b/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useState } from 'react';
+import {
+  Dispatch, SetStateAction, useEffect, useState,
+} from 'react';
 import { ReactComponent as DeleteImgIcon } from 'assets/svg/addmenu/mobile-delete-new-image.svg';
 import { MyShopInfoRes } from 'model/shopInfo/myShopInfo';
 import { ReactComponent as ImgPlusIcon } from 'assets/svg/mystore/imgplus.svg';
@@ -24,9 +26,11 @@ import styles from './EditShopInfoModal.module.scss';
 interface EditShopInfoModalProps {
   shopInfo: MyShopInfoRes;
   closeModal: () => void;
+  setIsSuccess: Dispatch<SetStateAction<boolean>>;
 }
 
-export default function EditShopInfoModal({ shopInfo, closeModal }: EditShopInfoModalProps) {
+export default function EditShopInfoModal({ shopInfo, closeModal, setIsSuccess }:
+EditShopInfoModalProps) {
   const { isMobile } = useMediaQuery();
   const [imageUrlList, setImageUrlList] = useState<string[]>(shopInfo.image_urls);
   const {
@@ -68,7 +72,10 @@ export default function EditShopInfoModal({ shopInfo, closeModal }: EditShopInfo
 
   const mutation = useMutation({
     mutationFn: (form: OwnerShop) => putShop(shopInfo.id, form),
-    onSuccess: closeModal,
+    onSuccess: () => {
+      closeModal();
+      setIsSuccess(true);
+    },
   });
 
   const handleDeleteImage = (image: string) => {

--- a/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
+++ b/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
@@ -103,7 +103,9 @@ export default function EditShopInfoModal({ shopInfo, closeModal }: EditShopInfo
     });
   }, []);
   const operateTimeState = useOperateTimeState();
-  const holiday = `매주 ${WEEK.filter((day) => shopClosedState[day]).join('요일, ')}요일`;
+  const holiday = WEEK.filter((day) => shopClosedState[day]).length > 0
+    ? `매주 ${WEEK.filter((day) => shopClosedState[day]).join('요일, ')}요일`
+    : '휴무일 없음';
 
   useEffect(() => {
     if (imageFile && !isMobile) {

--- a/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
+++ b/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
@@ -172,11 +172,11 @@ export default function EditShopInfoModal({ shopInfo, closeModal }: EditShopInfo
             </label>
           </div>
           <div className={styles['mobile-container__main-content']}>
-            <label htmlFor="name" className={styles['mobile-main-info']}>
+            <label htmlFor="shopName" className={styles['mobile-main-info']}>
               <span className={styles['mobile-main-info--header']}>가게명</span>
               <input
                 type="text"
-                id="name"
+                id="shopName"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 className={styles['mobile-main-info--input']}
@@ -238,11 +238,11 @@ export default function EditShopInfoModal({ shopInfo, closeModal }: EditShopInfo
                 </button>
               </div>
             </div>
-            <label htmlFor="address" className={styles['mobile-main-info']}>
+            <label htmlFor="shopAddress" className={styles['mobile-main-info']}>
               <span className={styles['mobile-main-info--header']}>주소정보</span>
               <input
                 type="text"
-                id="address"
+                id="shopAddress"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
                 className={styles['mobile-main-info--input']}
@@ -341,21 +341,21 @@ export default function EditShopInfoModal({ shopInfo, closeModal }: EditShopInfo
           </div>
           <hr className={styles['container__horizontal-line']} />
           <div className={styles.content}>
-            <label htmlFor="name" className={styles['main-info']}>
+            <label htmlFor="shopName" className={styles['main-info']}>
               <span className={styles['main-info__header']}>가게명</span>
               <input
                 type="text"
-                id="name"
+                id="shopName"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 className={styles['main-info__input']}
               />
             </label>
-            <label htmlFor="address" className={styles['main-info']}>
+            <label htmlFor="shopAddress" className={styles['main-info']}>
               <span className={styles['main-info__header']}>주소정보</span>
               <input
                 type="text"
-                id="address"
+                id="shopAddress"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
                 className={styles['main-info__input']}

--- a/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
+++ b/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
@@ -16,6 +16,7 @@
   }
 
   &__imgs-main-pic {
+    object-fit: contain;
     height: 257px;
   }
 
@@ -194,8 +195,10 @@
   }
 
   &__imgs-main-pic {
+    object-fit: contain;
     width: 368px;
     height: 257px;
+    box-shadow: 0 0 1px 0 #00000080;
   }
 
   &__subimgs {
@@ -227,6 +230,7 @@
     justify-content: center;
     align-items: center;
     margin: 0 auto;
+    object-fit: contain;
     width: 120px;
     height: 120px;
     border: 3px solid #175c8e;

--- a/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
+++ b/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
@@ -198,7 +198,6 @@
     object-fit: contain;
     width: 368px;
     height: 257px;
-    box-shadow: 0 0 1px 0 #00000080;
   }
 
   &__subimgs {
@@ -222,6 +221,7 @@
   &__subimgs-pic {
     width: 176px;
     height: 121px;
+    object-fit: contain;
   }
 
   &__empty-img {

--- a/src/page/MyShopPage/components/ShopInfo/index.tsx
+++ b/src/page/MyShopPage/components/ShopInfo/index.tsx
@@ -137,14 +137,26 @@ export default function ShopInfo({
               <img src={shopInfo.image_urls[0]} alt="main" className={styles['store__imgs-main-pic']} />
             </div>
             <div className={styles.store__subimgs}>
-              <div className={styles['store__empty-img']}>
-                <CUTLERY className={styles['store__empty-img-icon']} />
-                <span className={styles['store__empty-img-caption']}>이미지 준비 중</span>
-              </div>
-              <div className={styles['store__empty-img']}>
-                <CUTLERY className={styles['store__empty-img-icon']} />
-                <span className={styles['store__empty-img-caption']}>이미지 준비 중</span>
-              </div>
+              {shopInfo.image_urls[1] ? (
+                <div className={styles.store__subimg}>
+                  <img src={shopInfo.image_urls[1]} alt="sub" className={styles['store__subimgs-pic']} />
+                </div>
+              ) : (
+                <div className={styles['store__empty-img']}>
+                  <CUTLERY className={styles['store__empty-img-icon']} />
+                  <span className={styles['store__empty-img-caption']}>이미지 준비 중</span>
+                </div>
+              )}
+              {shopInfo.image_urls[2] ? (
+                <div className={styles.store__subimg}>
+                  <img src={shopInfo.image_urls[2]} alt="sub" className={styles['store__subimgs-pic']} />
+                </div>
+              ) : (
+                <div className={styles['store__empty-img']}>
+                  <CUTLERY className={styles['store__empty-img-icon']} />
+                  <span className={styles['store__empty-img-caption']}>이미지 준비 중</span>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/page/MyShopPage/components/ShopInfo/index.tsx
+++ b/src/page/MyShopPage/components/ShopInfo/index.tsx
@@ -4,17 +4,19 @@ import { ReactComponent as CUTLERY } from 'assets/svg/mystore/cutlery.svg';
 import { DAY_OF_WEEK, WEEK } from 'utils/constant/week';
 import CustomModal from 'component/common/CustomModal';
 import EditShopInfoModal from 'page/MyShopPage/components/EditShopInfoModal';
+import { Dispatch, SetStateAction } from 'react';
 import styles from './ShopInfo.module.scss';
 
 interface ShopInfoProps {
   shopInfo: MyShopInfoRes;
   openEditShopInfoModal: () => void;
   closeEditShopInfoModal: () => void;
+  setIsSuccess: Dispatch<SetStateAction<boolean>>;
   isEditShopInfoModalOpen: boolean;
 }
 
 export default function ShopInfo({
-  shopInfo, openEditShopInfoModal, closeEditShopInfoModal, isEditShopInfoModalOpen,
+  shopInfo, openEditShopInfoModal, closeEditShopInfoModal, setIsSuccess, isEditShopInfoModalOpen,
 }: ShopInfoProps) {
   const { isMobile } = useMediaQuery();
 
@@ -121,7 +123,11 @@ export default function ShopInfo({
                   onCancel={closeEditShopInfoModal}
                   isOverflowVisible
                 >
-                  <EditShopInfoModal shopInfo={shopInfo} closeModal={closeEditShopInfoModal} />
+                  <EditShopInfoModal
+                    shopInfo={shopInfo}
+                    closeModal={closeEditShopInfoModal}
+                    setIsSuccess={setIsSuccess}
+                  />
                 </CustomModal>
               )}
             </div>

--- a/src/page/MyShopPage/index.tsx
+++ b/src/page/MyShopPage/index.tsx
@@ -3,7 +3,8 @@ import useAddMenuStore from 'store/addMenu';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import { Link, useNavigate } from 'react-router-dom';
 import useBooleanState from 'utils/hooks/useBooleanState';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import showToast from 'utils/ts/showToast';
 import CatagoryMenuList from './components/CatagoryMenuList';
 import StoreInfo from './components/ShopInfo';
 import styles from './MyShopPage.module.scss';
@@ -25,6 +26,12 @@ export default function MyShopPage() {
     value: isEditShopInfoModalOpen,
   } = useBooleanState(false);
 
+  const [isSuccess, setIsSuccess] = useState(false);
+  if (isSuccess) {
+    showToast('success', '가게정보가 수정되었습니다.');
+    setIsSuccess(false);
+  }
+
   useEffect(() => {
     refetchShopData();
   }, [refetchShopData, isEditShopInfoModalOpen]);
@@ -41,7 +48,11 @@ export default function MyShopPage() {
         <div className={styles.mobileheader}>
           <h1 className={styles.mobileheader__title}>가게정보</h1>
         </div>
-        <EditShopInfoModal shopInfo={shopData} closeModal={closeEditShopInfoModal} />
+        <EditShopInfoModal
+          shopInfo={shopData}
+          closeModal={closeEditShopInfoModal}
+          setIsSuccess={setIsSuccess}
+        />
       </>
     );
   }
@@ -68,6 +79,7 @@ export default function MyShopPage() {
               openEditShopInfoModal={openEditShopInfoModal}
               closeEditShopInfoModal={closeEditShopInfoModal}
               isEditShopInfoModalOpen={isEditShopInfoModalOpen}
+              setIsSuccess={setIsSuccess}
             />
           )}
           {menusData && menusData.menu_categories.map((category) => (
@@ -97,6 +109,7 @@ export default function MyShopPage() {
               openEditShopInfoModal={openEditShopInfoModal}
               closeEditShopInfoModal={closeEditShopInfoModal}
               isEditShopInfoModalOpen={isEditShopInfoModalOpen}
+              setIsSuccess={setIsSuccess}
             />
           )}
           {menusData && menusData.menu_categories.map((category) => (

--- a/src/page/ShopRegistration/component/Modal/OperateTimePC/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/OperateTimePC/index.tsx
@@ -20,10 +20,6 @@ export default function OperateTimePC() {
           [day]: !prev.shopClosedState[day],
         },
       };
-      if (prev.shopClosedState[day] && !newState.shopClosedState[day]) {
-        newState.openTimeState[day] = '00:00';
-        newState.closeTimeState[day] = '00:00';
-      }
       return newState;
     });
   };

--- a/src/page/ShopRegistration/view/Mobile/Main/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/Main/index.tsx
@@ -62,7 +62,7 @@ export default function Main() {
         {uploadError !== '' && <ErrorMessage message={ERRORMESSAGE[uploadError]} />}
       </div>
       <label
-        htmlFor="name"
+        htmlFor="shopName"
         className={cn({
           [styles.form__label]: true,
           [styles['form__label--error']]: name === '' && isError,
@@ -71,7 +71,7 @@ export default function Main() {
         가게명
         <input
           type="text"
-          id="name"
+          id="shopName"
           onChange={(e) => setName(e.target.value)}
           value={name}
           className={styles.form__input}
@@ -81,7 +81,7 @@ export default function Main() {
         {name === '' && isError && <ErrorMessage message={ERRORMESSAGE.name} />}
       </div>
       <label
-        htmlFor="address"
+        htmlFor="shopAddress"
         className={cn({
           [styles.form__label]: true,
           [styles['form__label--error']]: address === '' && isError,
@@ -90,7 +90,7 @@ export default function Main() {
         주소정보
         <input
           type="text"
-          id="address"
+          id="shopAddress"
           onChange={(e) => setAddress(e.target.value)}
           value={address}
           className={styles.form__input}

--- a/src/utils/ts/showToast.ts
+++ b/src/utils/ts/showToast.ts
@@ -1,0 +1,19 @@
+import { ToastOptions, toast } from 'react-toastify';
+
+const TOAST_TYPE = {
+  default: 'DEFAULT',
+  success: 'SUCCESS',
+  info: 'INFO',
+  error: 'ERROR',
+  warning: 'WARNING',
+} as const;
+
+type ToastType = keyof typeof TOAST_TYPE;
+
+const showToast = (type: ToastType, message: string) => toast(message, {
+  type: TOAST_TYPE[type] as ToastOptions['type'],
+  autoClose: 3000,
+  progressStyle: { background: '#175C8E' },
+});
+
+export default showToast;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,6 +3225,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -8131,6 +8136,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^10.0.4:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.4.tgz#6ecdbbf923a07fc45850e69b0566efc7bf733283"
+  integrity sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==
+  dependencies:
+    clsx "^2.1.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## [#127] request
- 가게명 - 주소정보를 브라우저가 id-password로 인식하지 않도록 수정
- 휴무일이 없는 경우 `휴무일 없음`으로 수정
- 가게 정보 수정과 내 상점의 `가게 메인 사진`에 `object-fit` 추가
- 휴무를 true에서 false로 변경하면 00:00으로 초기화되는 로직 삭제
- 가게 정보 수정 후 액션 추가
<!--
- Write here your development contents 
-->

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] Did you merge recent `develop` branch?

### Screenshot
![image](https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/74540646/83703903-e7a9-4ddb-a7ac-96e582980d55)


### Precautions (main files for this PR ...)
- 알림을 표현하기 위해서 쩝쩝박사에서 사용하는 `react-toastify` 라이브러리를 새로 추가했습니다.
- 각각의 에러 수정 사항은 커밋 내용을 확인하면 더욱 빠르게 확인할 수 있습니다!

Close #127 
