### PR TITLE
fix: 내상점 페이지 모바일 뷰 css 오류 수정

### DIFF
--- a/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
+++ b/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
@@ -17,7 +17,7 @@
 
   &__imgs-main-pic {
     object-fit: contain;
-    height: 257px;
+    width: 100%;
   }
 
   &__info {


### PR DESCRIPTION
## [#141] request

내 상점 페이지 메인 사진 가로 길이 넘침으로 인해 생기는 css 오류를 수정했습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot
<수정 전>
<img width="354" alt="Pasted Graphic" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/112807899/deb8bc36-d3ed-4d9c-b5d0-a965d8763245">

<수정 후>
<img width="340" alt="image" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/112807899/3bdb5131-e14d-4358-9227-c0d554f33c83">

### Precautions (main files for this PR ...)

Close #141 
