### PR TITLE
메뉴 삭제 버튼 이동, 가게정보 이미지 넘침 현상 수정

### DIFF
--- a/src/page/AddMenu/AddMenu.module.scss
+++ b/src/page/AddMenu/AddMenu.module.scss
@@ -28,6 +28,7 @@
     width: 100%;
     padding: 0 16px;
     margin-top: 16px;
+    margin-bottom: 16px;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/page/AddMenu/components/MenuName/MenuName.module.scss
+++ b/src/page/AddMenu/components/MenuName/MenuName.module.scss
@@ -4,7 +4,7 @@
   }
 
   &__caption {
-    margin: 16px 0 8px;
+    margin: 0 0 8px;
     color: #175c8e;
     font-size: 15px;
     font-weight: 500;
@@ -76,4 +76,28 @@
 .error-message {
   font-size: 14px;
   color: #f7941e;
+}
+
+.mobile-delete-menu-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.delete-menu-button {
+  width: 80px;
+  height: 40px;
+  border: 0.5px solid #858585;
+  font-size: 15px;
+  font-weight: 400;
+  color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #f05d3d;
+
+  &:hover {
+    cursor: pointer;
+  }
 }

--- a/src/page/AddMenu/components/MenuName/index.tsx
+++ b/src/page/AddMenu/components/MenuName/index.tsx
@@ -1,6 +1,8 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useAddMenuStore from 'store/addMenu';
 import { useErrorMessageStore } from 'store/errorMessageStore';
+import { useDeleteMenu } from 'query/menu';
+import { useNavigate, useParams } from 'react-router-dom';
 import styles from './MenuName.module.scss';
 
 interface MenuNameProps {
@@ -11,14 +13,33 @@ export default function MenuName({ isComplete }: MenuNameProps) {
   const { isMobile } = useMediaQuery();
   const { name, setName } = useAddMenuStore();
   const { menuError } = useErrorMessageStore();
+  const { menuId } = useParams();
+  const { deleteMenuMutation } = useDeleteMenu();
   const handleNameChange = (e : React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
+  };
+  const navigate = useNavigate();
+  const goMyShop = () => {
+    navigate('/');
+  };
+  const handleMobileDeleteMenu = () => {
+    deleteMenuMutation(Number(menuId));
+    goMyShop();
   };
 
   return (
     <div>
       {isMobile ? (
         <div className={styles.mobile__container}>
+          <div className={styles['mobile-delete-menu-container']}>
+            <button
+              className={styles['delete-menu-button']}
+              type="button"
+              onClick={handleMobileDeleteMenu}
+            >
+              메뉴 삭제
+            </button>
+          </div>
           <div className={styles.mobile__caption}>
             메뉴명
           </div>

--- a/src/page/ModifyMenu/index.tsx
+++ b/src/page/ModifyMenu/index.tsx
@@ -93,11 +93,6 @@ export default function ModifyMenu() {
     openGoMyShopModal();
   };
 
-  const handleMobileDeleteMenu = () => {
-    deleteMenuMutation(Number(menuId));
-    goMyShop();
-  };
-
   return (
     <div>
       {isMobile ? (
@@ -161,15 +156,6 @@ export default function ModifyMenu() {
               </>
             )}
 
-          </div>
-          <div className={styles['mobile-delete-menu-container']}>
-            <button
-              className={styles['delete-menu-button']}
-              type="button"
-              onClick={handleMobileDeleteMenu}
-            >
-              메뉴 삭제
-            </button>
           </div>
         </div>
       ) : (

--- a/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
+++ b/src/page/MyShopPage/components/ShopInfo/ShopInfo.module.scss
@@ -18,6 +18,7 @@
   &__imgs-main-pic {
     object-fit: contain;
     width: 100%;
+    height: 100%;
   }
 
   &__info {


### PR DESCRIPTION
## [#144 ] request

- 가게정보 이미지가 넘쳐서 헤더를 가리는 문제를 수정했습니다.
- 모바일 환경에서 메뉴 삭제 버튼이 취소, 수정버튼과 비슷한 위치에 있어 잘못 누를 가능성을 줄이고자 상단으로 이동했습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] Did you merge recent `develop` branch?

### Screenshot

<img width="470" alt="스크린샷 2024-03-03 오후 4 32 45" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/56b6b5e2-4bbd-4fd2-a290-05d513c13227">
<img width="465" alt="스크린샷 2024-03-03 오후 4 32 53" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/9f780d7a-5f60-4ef2-81ce-3733844c20ce">

### Precautions (main files for this PR ...)

- Close #144 
