### PR TITLE
[영양사] 모바일 크롬에서 사진촬영이 불가능한 이슈 수정

### DIFF
--- a/src/page/Coop/components/MenuCard/index.tsx
+++ b/src/page/Coop/components/MenuCard/index.tsx
@@ -167,6 +167,7 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
               <input
                 type="file"
                 accept="image/*"
+                capture
                 style={{ display: 'none' }}
                 onChange={menu ? handleImageChange(menu.id) : undefined}
                 ref={(el) => {

--- a/src/page/Coop/components/SoldoutToggle/SoldoutToggle.module.scss
+++ b/src/page/Coop/components/SoldoutToggle/SoldoutToggle.module.scss
@@ -2,12 +2,10 @@
   width: 46px;
   height: 23px;
   cursor: pointer;
-  transition: fill 0.3s ease-in-out;
 
   .background,
   .circle {
     rx: 9.5;
     stroke-width: 3;
-    transition: fill 0.3s ease-in-out;
   }
 }


### PR DESCRIPTION
- Close #246
  
## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 모바일 크롬에서 사진촬영이 가능하도록 수정
- issue : #246

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 기존 모바일 크롬에서는 사진촬영이 불가능하고 갤러리에서 기존 사진을 선택만 할 수 있는 문제를 수정했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->
local환경을 모바일에서 직접 테스트 할 방법이 없어 병합 후 스테이지 서버에서 테스트해보겠습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] Did you merge recent `develop` branch?
