### PR TITLE
관리자 승인 후 로그인 시 가게 등록이 안되던 문제 수정

### DIFF
--- a/src/page/ShopRegistration/view/Mobile/ShopConfirmation/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/ShopConfirmation/index.tsx
@@ -5,13 +5,25 @@ import useOperateTimeState from 'page/ShopRegistration/hooks/useOperateTimeState
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { OwnerShop } from 'model/shopInfo/ownerShop';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postShop } from 'api/shop';
 import { useEffect } from 'react';
 import { DAY_OF_WEEK, WEEK } from 'utils/constant/week';
 import useModalStore from 'store/modalStore';
 import CheckSameTime from 'page/ShopRegistration/hooks/CheckSameTime';
 import styles from './ShopConfirmation.module.scss';
+
+const usePostData = (setStep: (step: number) => void) => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (form: OwnerShop) => postShop(form),
+    onSuccess: () => {
+      setStep(5);
+      queryClient.refetchQueries();
+    },
+  });
+  return mutation;
+};
 
 export default function ShopConfirmation() {
   const { setStep } = useStepStore();
@@ -35,10 +47,7 @@ export default function ShopConfirmation() {
     resolver: zodResolver(OwnerShop),
   });
 
-  const mutation = useMutation({
-    mutationFn: (form: OwnerShop) => postShop(form),
-    onSuccess: () => setStep(5),
-  });
+  const mutation = usePostData(setStep);
 
   const onSubmit: SubmitHandler<OwnerShop> = (data) => {
     mutation.mutate(data);

--- a/src/query/shop.ts
+++ b/src/query/shop.ts
@@ -20,7 +20,7 @@ const useMyShop = () => {
   const prevShopId = Number(localStorage.getItem('myShopId'));
   const prevShop = prevShopId ? myShop.shops.find((shop) => shop.id === prevShopId) : null;
 
-  const currentMyShopId = prevShop ? prevShop.id : myShop.shops[0].id;
+  const currentMyShopId = prevShop ? prevShop.id : myShop.shops[0]?.id;
 
   const shopId = currentMyShopId;
 


### PR DESCRIPTION
  ## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 :  관리자 승인 후 로그인 시 가게 등록이 안되던 문제 수정

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
가게등록 시 useMyShop에서 카테고리를 받아오는데 이때 myShop이 호출되면서 
myShop.shops[0].id; 에서 에러가 발생함
이것을 수정했습니다

그리고 가게등록 후 가게 정보를 다시 받아오도록 수정했습니다
## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] Did you merge recent `develop` branch?
