### PR TITLE
[영양사] 품절취소기능 버그 수정

### DIFF
--- a/src/page/Coop/components/MenuCard/index.tsx
+++ b/src/page/Coop/components/MenuCard/index.tsx
@@ -78,9 +78,9 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
     setSelectedCorner(corner || null);
     if (menu?.soldout_at === null) {
       setIsSoldoutModalOpen((prev) => !prev);
-    } else if (selectedMenu) {
+    } else if (menu) {
       updateSoldOutMutation({
-        menu_id: selectedMenu.id,
+        menu_id: menu.id,
         sold_out: false,
       });
     }
@@ -113,7 +113,6 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
                   {menu && <span className={styles.card__soldout}>품절</span>}
                   {menu && (
                   <SoldoutToggle
-                    menuId={menu.id}
                     onClick={() => handleToggleSoldoutModal(menu, corner)}
                     menu={menu}
                   />

--- a/src/page/Coop/components/SoldoutToggle/index.tsx
+++ b/src/page/Coop/components/SoldoutToggle/index.tsx
@@ -3,18 +3,17 @@ import useToggleStore from 'store/soldoutToggleStore';
 import styles from './SoldoutToggle.module.scss';
 
 interface SoldoutToggleProps {
-  menuId: number;
   onClick: () => void;
   menu: Dinings;
 }
 
-export default function SoldoutToggle({ menuId, onClick, menu }: SoldoutToggleProps) {
+export default function SoldoutToggle({ onClick, menu }: SoldoutToggleProps) {
   const { isSoldOut, toggleSoldOut } = useToggleStore();
-  const isActive = isSoldOut[menuId] ?? menu.soldout_at;
+  const isActive = isSoldOut[menu.id] ?? menu.soldout_at;
 
   const handleToggle = () => {
     onClick();
-    toggleSoldOut(menuId);
+    toggleSoldOut(menu.id);
   };
 
   return (


### PR DESCRIPTION
- Close #275
  
## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 품절 취소 기능 버그 수정
- issue : #275

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
A,B,C코너가 품절이 되고, C코너, B코너, A코너 순으로 품절취소를 했을 때 C,B,A순서가 아닌 A,B,C 순서로 품절취소가 되던 버그를 수정했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/b5fbd2a4-c75d-4876-922a-0222579c9fd8



## Test CheckList ✅

<!-- 
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] Did you merge recent `develop` branch?
