### PR TITLE
[영양사] 품절취소 모달 구현

### DIFF
--- a/src/page/Coop/components/MenuCard/index.tsx
+++ b/src/page/Coop/components/MenuCard/index.tsx
@@ -79,10 +79,7 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
     if (menu?.soldout_at === null) {
       setIsSoldoutModalOpen((prev) => !prev);
     } else if (menu) {
-      updateSoldOutMutation({
-        menu_id: menu.id,
-        sold_out: false,
-      });
+      setIsSoldoutModalOpen((prev) => !prev);
     }
   };
 
@@ -91,10 +88,16 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
   };
 
   const handleSoldoutModalConfirm = () => {
-    if (selectedMenu) {
+    if (selectedMenu && selectedMenu.soldout_at === null) {
       updateSoldOutMutation({
         menu_id: selectedMenu.id,
         sold_out: true,
+      });
+      setIsSoldoutModalOpen(false);
+    } else if (selectedMenu && selectedMenu.soldout_at) {
+      updateSoldOutMutation({
+        menu_id: selectedMenu.id,
+        sold_out: false,
       });
       setIsSoldoutModalOpen(false);
     }
@@ -187,7 +190,7 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
         onCancel={handleToggleSoldoutModal}
         buttonText="품절설정"
       >
-        {selectedMenu && selectedCorner && (
+        {selectedMenu?.soldout_at === null ? (selectedMenu && selectedCorner && (
           <div className={styles.modal}>
             <span className={styles.modal__header}>
               {selectedCorner}
@@ -196,7 +199,7 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
               <span className={styles['modal__header--primary']}>품절 상태</span>
               로 설정할까요?
             </span>
-            <span className={styles.modal__description}>품절 상태는 복구할 수 없습니다.</span>
+            <span className={styles.modal__description}>알림이 발송되니 신중하게 설정해주세요.</span>
             <div className={styles.modal__wrapper}>
               <button type="button" onClick={handleSoldoutModalClose} className={styles.modal__button}>
                 취소
@@ -206,8 +209,27 @@ export default function MenuCard({ selectedMenuType }: MenuCardProps) {
               </button>
             </div>
           </div>
-        )}
-
+        ))
+          : (selectedMenu && selectedCorner && (
+            <div className={styles.modal}>
+              <span className={styles.modal__header}>
+                {selectedCorner}
+                를
+                {' '}
+                <span className={styles['modal__header--primary']}>품절 취소</span>
+                로 설정할까요?
+              </span>
+              <span className={styles.modal__description}>이미 발송된 알림은 취소되지 않습니다.</span>
+              <div className={styles.modal__wrapper}>
+                <button type="button" onClick={handleSoldoutModalClose} className={styles.modal__button}>
+                  취소
+                </button>
+                <button type="button" onClick={handleSoldoutModalConfirm} className={styles['modal__button--primary']}>
+                  품절취소
+                </button>
+              </div>
+            </div>
+          ))}
       </SoldoutModal>
     </>
   );


### PR DESCRIPTION
- Close #291
  
## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 품절취소 모달창 구현
- issue : #291

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 기존 품절 모달창 내용 수정
- 품절 취소 모달창 구현

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="49%" alt="스크린샷 2024-04-19 오후 4 29 18" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/3507b764-6049-435e-bd84-e1edb5eda242">
<img width="49%" alt="스크린샷 2024-04-19 오후 4 29 25" src="https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/51395707/28f84a68-f5c6-46ed-9619-eaf8c495f459">


## Test CheckList ✅

<!-- 
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] Did you merge recent `develop` branch?
