### PR TITLE
[공통] 데이터가 stale일때 refetch 되도록 수정

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,9 +15,9 @@ const root = ReactDOM.createRoot(
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
+      refetchOnWindowFocus: true,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
       retry: 1,
       staleTime: 1000 * 60 * 5,
       throwOnError: (err) => err instanceof ZodError,


### PR DESCRIPTION
- Close #296 
  
## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 :  queryClient 재정의
- issue :  #296 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
기존 queryClient 설정을 보면  refetchOnMount가 false로 지정되어 있어 쿼리 무효화를 시켜서 데이터가 stale상태가 되어도 refect가 안되는 경우가 있었습니다. 이 값을 true로 바꿔서 invalidationQueries가 원하는대로 동작하도록 수정했습니다.
또한 추가로 refetchOnWindowFocus, refetchOnReconnect도 false인 점이 불필요하다고 판단되어 true로 수정했습니다.

기존에 invalidation이 동작하지 않아서 refetchQueries 또는 useQuery의 refetch를 사용하신 부분이 많이 있을 겁니다.
자신이 수정했던 부분을 기억하셔서 불필요한 refetch가 이루어지지 않는지 다들 한번씩 확인 부탁드리겠습니다
## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
![image](https://github.com/BCSDLab/KOIN_OWNER_WEB/assets/101871802/ed5c242a-b615-4d99-a06d-be6b66e8cb68)

## Test CheckList ✅

<!-- 
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] Did you merge recent `develop` branch?
