### PR TITLE
[가게 정보 기입] 초기 이미지 에러 수정 및 등록 과정 회원가입이랑 동일하게 진행

### DIFF
--- a/src/page/Auth/Signup/view/OwnerDataPage/index.tsx
+++ b/src/page/Auth/Signup/view/OwnerDataPage/index.tsx
@@ -133,7 +133,7 @@ export default function OwnerData({ goNext }:ButtonClickEvent) {
             {ownerData.registerFiles ? (
               <div className={styles['file-box__files']}>
                 {ownerData.registerFiles.map((file:File, index:number) => (
-                  <button type="button" className={styles['file-box__file']} onClick={(e) => onClick(index, e)}>
+                  <button key={file.name} type="button" className={styles['file-box__file']} onClick={(e) => onClick(index, e)}>
                     <FileImage />
                     <span className={styles['file-box__file--name']}>{file.name}</span>
                   </button>

--- a/src/page/ShopRegistration/view/PC/ShopRegistrationPC.module.scss
+++ b/src/page/ShopRegistration/view/PC/ShopRegistrationPC.module.scss
@@ -99,7 +99,7 @@ input::-webkit-inner-spin-button {
     border: 1px solid #d2dae2;
     padding: 53px 80px 54px;
     cursor: pointer;
-  
+
     &--active {
       display: flex;
       flex-direction: column;
@@ -130,7 +130,7 @@ input::-webkit-inner-spin-button {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    word-break:break-all;
+    word-break: break-all;
     color: #858585;
   }
 

--- a/src/page/ShopRegistration/view/PC/ShopRegistrationPC.module.scss
+++ b/src/page/ShopRegistration/view/PC/ShopRegistrationPC.module.scss
@@ -99,6 +99,15 @@ input::-webkit-inner-spin-button {
     border: 1px solid #d2dae2;
     padding: 53px 80px 54px;
     cursor: pointer;
+  
+    &--active {
+      display: flex;
+      flex-direction: column;
+      padding: 10px 20px;
+      width: 340px;
+      height: 180px;
+      justify-content: flex-start;
+    }
   }
 
   &__upload-file {
@@ -108,6 +117,21 @@ input::-webkit-inner-spin-button {
   &__main-menu {
     max-width: 370px;
     max-height: 200px;
+  }
+
+  &__main-item {
+    max-width: 370px;
+    display: flex;
+    z-index: 99;
+  }
+
+  &__main-text {
+    width: 90%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    word-break:break-all;
+    color: #858585;
   }
 
   &__cutlery-cross {

--- a/src/page/ShopRegistration/view/PC/index.tsx
+++ b/src/page/ShopRegistration/view/PC/index.tsx
@@ -14,6 +14,7 @@ import ConfirmPopup from 'page/ShopRegistration/component/ConfirmPopup';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import CustomModal from 'component/common/CustomModal';
+import cn from 'utils/ts/className';
 import useModalStore from 'store/modalStore';
 import { WEEK, DAY_OF_WEEK } from 'utils/constant/week';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -26,6 +27,7 @@ import useShopRegistrationStore from 'store/shopRegistration';
 import ErrorMessage from 'page/Auth/Signup/component/ErrorMessage';
 import { ERRORMESSAGE } from 'page/ShopRegistration/constant/errorMessage';
 import { usePostData } from 'page/ShopRegistration/view/Mobile/ShopConfirmation/index';
+import { ReactComponent as FileImage } from 'assets/svg/auth/default-file.svg';
 import styles from './ShopRegistrationPC.module.scss';
 
 export default function ShopRegistrationPC() {
@@ -53,7 +55,7 @@ export default function ShopRegistrationPC() {
     setFalse: closeConfirmPopup,
   } = useBooleanState(false);
   const {
-    imageFile, imgRef, saveImgFile, uploadError,
+    imageFile, imgRef, saveImgFile, uploadError, setImageFile,
   } = useImagesUpload();
   const [isError, setIsError] = useState(false);
 
@@ -73,6 +75,7 @@ export default function ShopRegistrationPC() {
     setPhone,
     setDeliveryPrice,
     setDescription,
+    removeImageUrl,
   } = useShopRegistrationStore();
 
   const {
@@ -125,6 +128,12 @@ export default function ShopRegistrationPC() {
   const openTimeArray = Object.values(openTimeState);
   const closeTimeArray = Object.values(closeTimeState);
   const shopClosedArray = Object.values(shopClosedState);
+
+  const onClickRemoveImageUrl = (e: React.MouseEvent<HTMLDivElement>, imageUrl: string) => {
+    e.preventDefault();
+    setImageFile(imageFile.filter((img) => img !== imageUrl));
+    removeImageUrl(imageUrl);
+  };
 
   useEffect(() => {
     if (imageFile.length > 0 || uploadError !== '') setImageUrls(imageFile);
@@ -183,7 +192,13 @@ export default function ShopRegistrationPC() {
             <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
               <div>
                 <span className={styles.form__title}>대표 이미지</span>
-                <label className={styles['form__image-upload']} htmlFor="mainMenuImage">
+                <label
+                  className={cn({
+                    [styles['form__image-upload']]: true,
+                    [styles['form__image-upload--active']]: imageUrls.length !== 0,
+                  })}
+                  htmlFor="mainMenuImage"
+                >
                   <input
                     type="file"
                     accept="image/*"
@@ -193,9 +208,20 @@ export default function ShopRegistrationPC() {
                     onChange={saveImgFile}
                     ref={imgRef}
                   />
-                  {imageUrls
-                    ? <img src={imageUrls[0]} className={styles['form__main-menu']} alt="메인 메뉴" />
-                    : (
+                  {imageUrls.length !== 0
+                    ? (
+                      imageUrls.map((imageUrl: string) => (
+                        <div
+                          key={imageUrl}
+                          className={styles['form__main-item']}
+                          onClick={(e) => onClickRemoveImageUrl(e, imageUrl)}
+                          aria-hidden
+                        >
+                          <FileImage />
+                          <div className={styles['form__main-text']}>{imageUrl}</div>
+                        </div>
+                      ))
+                    ) : (
                       <>
                         <Cutlery className={styles['form__cutlery-cross']} />
                         <span className={styles.form__text}>클릭하여 이미지를 등록해주세요.</span>

--- a/src/query/register.ts
+++ b/src/query/register.ts
@@ -1,8 +1,8 @@
+import { isKoinError } from '@bcsdlab/koin';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   getEmailAuthCode, getEmailDuplicate, getFileUrls, registerUser, verificationAuthCode,
 } from 'api/register';
-import axios from 'axios';
 import parseRegisterData from 'page/Auth/Signup/utils/parseRegisterData';
 import useRegisterInfo from 'store/registerStore';
 import useShopRegistrationStore from 'store/shopRegistration';
@@ -85,8 +85,8 @@ export const useGetFileUrls = (goNext:()=>void) => {
         try {
           await register.mutateAsync(data.file_urls);
         } catch (e) {
-          if (axios.isAxiosError(e)) {
-            showToast('error', `${e.response?.data.message || e.message}`);
+          if (isKoinError(e)) {
+            showToast('error', `${e.message}`);
           }
         }
       } catch (e) {

--- a/src/store/shopRegistration.ts
+++ b/src/store/shopRegistration.ts
@@ -39,7 +39,7 @@ const useShopRegistrationStore = create<ShopRegistrationStore>((set) => ({
   deliveryPrice: 0,
   description: '',
   imageUrl: '',
-  imageUrls: [],
+  imageUrls: ['aa'],
   owner: '',
   name: '',
   phone: '',
@@ -56,8 +56,8 @@ const useShopRegistrationStore = create<ShopRegistrationStore>((set) => ({
   setImageUrls: (newImageUrls: string[]) => set({
     imageUrls: newImageUrls,
   }),
-  removeImageUrl: (imageUrlToRemove) => set((state) => ({
-    imageUrls: state.imageUrls.filter((img) => img !== imageUrlToRemove),
+  removeImageUrl: (imageUrl: string) => set((state) => ({
+    imageUrls: state.imageUrls.filter((img) => img !== imageUrl),
   })),
   setOwner: (owner: string) => set({ owner }),
   setName: (name: string) => set({ name }),


### PR DESCRIPTION
- Close #329
  
## What is this PR? 🔍

<!-- 
ex) 
- 기능 : 회원 정보 삭제 기능
- issue : #81
-->

- 기능 : 가게 정보기입 에러 수정 및 이미지 등록 과정 수정
- issue : #329

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
큰 이미지만 보여주는 것이 아닌 회원가입시 등록하는 이미지를 하나씩 보여주는 방식으로 변경하였습니다.

초기 이미지가 깨져나오는 걸 수정했습니다.


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
ex) 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

## Precaution

<!-- 유의 사항 -->

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] Did you merge recent `develop` branch?
