### PR TITLE
[비즈니스] 비밀번호 sha256으로 해싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,9 +75,9 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route element={<CommonLayout />}>
               <Route path="/signup" element={<Signup />} />
-              <Route path="/find-id" element={<PageNotFound />} />
               <Route path="/find-password" element={<FindPassword />} />
             </Route>
+            <Route path="/find-id" element={<PageNotFound />} />
           </Route>
         </Route>
       </Routes>

--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -125,7 +125,7 @@ export default function Login() {
                   {OPTION[1].name}
                 </Link>
               )
-              : OPTION.map((option) => (
+              : OPTION.filter((option) => option.name !== '아이디 찾기').map((option) => (
                 <Link to={option.path} key={option.name} className={styles.option__link}>
                   {option.name}
                 </Link>

--- a/src/page/Auth/components/Common/index.tsx
+++ b/src/page/Auth/components/Common/index.tsx
@@ -13,12 +13,13 @@ import sha256 from 'utils/ts/SHA-256';
 import Done from '../Done/index';
 import styles from './index.module.scss';
 
-const setNewPassword = (
+const setNewPassword = async (
   phone_number: string,
   password: string,
   setError: UseFormSetError<Register>,
 ) => {
-  changePassword({ phone_number, password })
+  const hashPassword = await sha256(password);
+  changePassword({ phone_number, password: hashPassword })
     .catch((e) => {
       if (isKoinError(e)) {
         setError('password', { type: 'custom', message: e.message });


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 비밀번호 sha256으로 해싱
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
로그인 시 sha256으로 해싱한 비밀번호를 받기 때문에 해싱해서 보내도록 수정
이제 비밀번호 찾기 정상 동작


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
