### PR TITLE
[비즈니스] 회원가입 인증번호 확인 버튼, 토스트 추가

### DIFF
--- a/src/page/Auth/Signup/components/phoneStep/phoneStep.module.scss
+++ b/src/page/Auth/Signup/components/phoneStep/phoneStep.module.scss
@@ -1,7 +1,8 @@
 @use "src/utils/styles/mediaQuery" as media;
 
 .default-info {
-  width: 100%;
+  width: 98%;
+  margin-left: 1%;
   margin-top: 25px;
   display: flex;
   flex-direction: column;
@@ -59,10 +60,18 @@
   }
 }
 
+.verification-code__input {
+  width: 66.67% !important;
+}
+
 .verification-code__button {
   &--active {
     background-color: #175c8e !important;
     color: white !important;
+  }
+
+  &--error {
+    background-color: #f7941e !important;
   }
 }
 


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 회원가입 인증번호 확인 버튼, 토스트 추가
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
인증번호 확인을 기존에는 6자리가 되면 자동으로 확인하였지만 확인 버튼으로 확인 할 수 있도록 변경
인증번호 전송, 확인 토스트 추가


## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
<img width="404" alt="image" src="https://github.com/user-attachments/assets/9f496876-1e76-4bce-9729-2bdb29078a20">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f27dbe76-f223-48bb-877a-2be6d4274f40">

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
