### PR TITLE
[비즈니스] 폼 재입력시 에러 초기화

### DIFF
--- a/src/page/Auth/Signup/components/phoneStep/index.tsx
+++ b/src/page/Auth/Signup/components/phoneStep/index.tsx
@@ -85,7 +85,7 @@ const useCheckCode = (
 
 export default function PhoneStep({ setIsStepComplete }: PhoneStepProps) {
   const {
-    register, formState: { errors }, getValues, setError, watch, setValue,
+    register, formState: { errors }, getValues, setError, watch, setValue, clearErrors,
   } = useFormContext<Verify>();
 
   const [isSent, setIsSent] = useState(false);
@@ -116,6 +116,8 @@ export default function PhoneStep({ setIsStepComplete }: PhoneStepProps) {
       value = value.slice(0, 11);
     }
     setValue('phone_number', value);
+    setIsClick(false);
+    clearErrors();
   };
 
   const watchedValues = watch(['attachment_urls', 'verificationCode', 'password', 'passwordConfirm']);
@@ -163,7 +165,6 @@ export default function PhoneStep({ setIsStepComplete }: PhoneStepProps) {
               [styles['verification-code__button--active']]: isSent || !isClick,
             })}
             onClick={sendCode}
-            disabled={isClick}
           >
             {isSent ? '인증번호 재발송' : '인증번호 발송'}
           </button>
@@ -204,7 +205,6 @@ export default function PhoneStep({ setIsStepComplete }: PhoneStepProps) {
               [styles['verification-code__button--error']]: !!errors.verificationCode,
             })}
             onClick={checkCode}
-            disabled={isCertified}
           >
             인증번호 확인
           </button>

--- a/src/page/Auth/Signup/components/phoneStep/index.tsx
+++ b/src/page/Auth/Signup/components/phoneStep/index.tsx
@@ -165,6 +165,7 @@ export default function PhoneStep({ setIsStepComplete }: PhoneStepProps) {
               [styles['verification-code__button--active']]: isSent || !isClick,
             })}
             onClick={sendCode}
+            disabled={isClick}
           >
             {isSent ? '인증번호 재발송' : '인증번호 발송'}
           </button>


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

폼 재입력시 에러를 초기화해서 유저의 대응에 유연하게 반응했습니다

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
