### PR TITLE
[비즈니스] 비밀번호 자동완성 막기

### DIFF
--- a/src/page/Auth/Login/index.tsx
+++ b/src/page/Auth/Login/index.tsx
@@ -72,6 +72,7 @@ export default function Login() {
               type={isBlind ? 'text' : 'password'}
               placeholder={isMobile ? '비밀번호' : '비밀번호 입력'}
               {...register('password')}
+              autoComplete="new-password"
             />
             <button
               type="button"

--- a/src/page/MyShopPage/components/BankList/index.tsx
+++ b/src/page/MyShopPage/components/BankList/index.tsx
@@ -1,6 +1,7 @@
 import { OwnerShop } from 'model/shopInfo/ownerShop';
-import { UseFormSetValue, UseFormRegister } from 'react-hook-form';
+import { UseFormSetValue, UseFormRegister, UseFormSetFocus } from 'react-hook-form';
 import { bank } from 'utils/constant/bank';
+import { useEffect } from 'react';
 import cn from 'utils/ts/className';
 import showToast from 'utils/ts/showToast';
 import styles from './index.module.scss';
@@ -11,11 +12,12 @@ interface Props {
   setValue: UseFormSetValue<OwnerShop>;
   bankName: string | null;
   account_number: string | null;
+  setFocus: UseFormSetFocus<OwnerShop>;
 }
 
 const NUMBER_REGEX = /^[0-9-]+$/;
 export default function BankList({
-  close, register, setValue, bankName, account_number,
+  close, register, setValue, bankName, account_number, setFocus,
 }: Props) {
   const validation = () => {
     if (account_number && !NUMBER_REGEX.test(account_number)) {
@@ -28,6 +30,12 @@ export default function BankList({
     }
     close();
   };
+
+  useEffect(() => {
+    setFocus('account_number');
+    // eslint-disable-next-line
+  }, []); // 마운트 시 한 번만 포커스
+
   return (
     <div className={styles.overlay} onClick={validation} role="button" aria-hidden>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()} role="button" aria-hidden>

--- a/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
+++ b/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
@@ -65,7 +65,7 @@ export default function EditShopInfoModal({
   } = CheckSameTime();
 
   const {
-    register, control, handleSubmit, setValue, formState: { errors },
+    register, control, handleSubmit, setValue, formState: { errors }, setFocus,
   } = useForm<OwnerShop>({
     resolver: zodResolver(OwnerShop),
     defaultValues: {
@@ -353,6 +353,7 @@ export default function EditShopInfoModal({
                 account_number={account}
                 setValue={setValue}
                 close={() => setIsOpen(false)}
+                setFocus={setFocus}
               />
             )}
             <label htmlFor="description" className={styles['mobile-main-info__label']}>
@@ -623,6 +624,7 @@ export default function EditShopInfoModal({
                 account_number={account}
                 setValue={setValue}
                 close={() => setIsOpen(false)}
+                setFocus={setFocus}
               />
             )}
           </div>


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
아이폰 사용자의 경우 비밀번호 인풋에 비밀번호가 자동 추천되는데, 길이가 18자를 넘어서 사용할 수 없는 불편함이 있습니다.
또한 계좌번호 바텀시트 마운트 시 포커스가 바뀌지 않아 크롬 브라우저에서 보기 불편했던 현상을 수정했습니다

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
