### PR TITLE
[메인 카테고리 추가] : 상점 생성 및 수정 시 메인 카테고리 기능 추가

### DIFF
--- a/src/model/shopInfo/allShopInfo.ts
+++ b/src/model/shopInfo/allShopInfo.ts
@@ -15,6 +15,7 @@ export const Shop = z.object({
   pay_bank: z.boolean(),
   pay_card: z.boolean(),
   open: z.array(Open),
+  main_category_id: z.number(),
   category_ids: z.array(z.number()),
 });
 

--- a/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
+++ b/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
@@ -98,6 +98,7 @@ export default function EditShopInfoModal({
 
   const handleCategoryIdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setValue('category_ids', [Number(e.target.value), 0]);
+    setValue('main_category_id', Number(e.target.value));
   };
 
   const handleDeleteImage = (image: string) => {

--- a/src/page/ShopRegistration/component/Modal/Category/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/Category/index.tsx
@@ -11,6 +11,7 @@ export default function Category() {
 
   const handleCategoryClick = (categoryInfo: CategoryProps) => {
     setValue('category_ids', [categoryInfo.id, 0]);
+    setValue('main_category_id', categoryInfo.id);
   };
 
   return (

--- a/src/page/ShopRegistration/view/Mobile/ShopCategory/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/ShopCategory/index.tsx
@@ -15,6 +15,7 @@ export default function ShopCategory({ onNext }:{ onNext: () => void }) {
 
   const handleCategoryClick = (categoryInfo: CategoryProps) => {
     setValue('category_ids', [categoryInfo.id, 0]);
+    setValue('main_category_id', categoryInfo.id);
   };
 
   const handleNextClick = () => {


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 상점 생성 및 수정 시 main_category_id 속성 포함
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->
- 상점 생성 및 수정시 zod 상태에 main_category_id가 추가되도록 코드를 수정했습니다.


## ScreenShot 📷
로직을 적용한 부분은 3 페이지입니다.
1. 상점 수정 모달
2. 초기 상점 생성 PC
3. 초기 상점 생성 모바일
2, 3번은 최초 회원가입 시 나오는 카테고리 부분입니다. 사장님 어플은 기본적으로 카테고리를 한번만 선택 가능해서 메인 카테고리를 동시에 결정하도록 수정하였습니다.

<img width="1359" alt="스크린샷 2024-11-18 오후 5 35 10" src="https://github.com/user-attachments/assets/53e953ca-87dc-4d8c-8367-646a642a814c">

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->
## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
