### PR TITLE
fix : main_category_id가 처음 회원 가입시에는 undefined이기 때문에 optional로 변경

### DIFF
--- a/src/model/shopInfo/allShopInfo.ts
+++ b/src/model/shopInfo/allShopInfo.ts
@@ -15,7 +15,7 @@ export const Shop = z.object({
   pay_bank: z.boolean(),
   pay_card: z.boolean(),
   open: z.array(Open),
-  main_category_id: z.number(),
+  main_category_id: z.number().optional(),
   category_ids: z.array(z.number()),
 });
 

--- a/src/model/shopInfo/myShopInfo.ts
+++ b/src/model/shopInfo/myShopInfo.ts
@@ -53,6 +53,7 @@ export const MyShopInfoRes = z.object({
   menu_categories: z.array(MenuCategory),
   bank: z.string().nullable(),
   account_number: z.string().nullable(),
+  main_category_id: z.number(),
 });
 
 export type MyShopInfoRes = z.infer<typeof MyShopInfoRes>;

--- a/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
+++ b/src/page/MyShopPage/components/EditShopInfoModal/index.tsx
@@ -77,7 +77,7 @@ export default function EditShopInfoModal({
         open_time: day.open_time,
         close_time: day.close_time,
       })),
-      main_category_id: shopInfo.shop_categories.map((category) => category.id)[0],
+      main_category_id: shopInfo.shop_categories.map((category) => category.id)[0] || 0,
     },
   });
 


### PR DESCRIPTION
- Close #ISSUE_NUMBER
  
## What is this PR? 🔍

- 기능 : 
- issue : #

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

main_category_id가 처음 회원 가입시에는 undefined이기 때문에 optional로 변경했는데 해당 값을 사용하는 곳에서 undefined된 값을 참조해서 에러가 발생하지 않는지 확인 부탁드립니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Test CheckList ✅

<!-- 
- [ ] 카테고리 설정이 null 로 들어가지 않는지 체크
-->

- [ ] test 1
- [ ] test 2
- [ ] test 3

## Precaution


## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`
