### PR TITLE
[상점 생성] 상점 주소 검증 추가 및 상세 주소 필드 분리

### DIFF
--- a/src/api/address/index.ts
+++ b/src/api/address/index.ts
@@ -1,0 +1,7 @@
+import { accessClient } from 'api';
+import { Address, AddressParams } from 'model/shopInfo/address';
+
+export const getAddress = async (params:AddressParams) => {
+  const { data } = await accessClient.get<Address>('/address/search', { params });
+  return Address.parse(data);
+};

--- a/src/api/address/index.ts
+++ b/src/api/address/index.ts
@@ -1,7 +1,7 @@
 import { accessClient } from 'api';
-import { Address, type AddressParams } from 'model/shopInfo/address';
+import { AddressSearchResponse, type AddressParams } from 'model/shopInfo/address';
 
 export const getAddress = async (params:AddressParams) => {
-  const { data } = await accessClient.get<Address>('/address/search', { params });
-  return Address.parse(data);
+  const { data } = await accessClient.get<AddressSearchResponse>('/address/search', { params });
+  return AddressSearchResponse.parse(data);
 };

--- a/src/api/address/index.ts
+++ b/src/api/address/index.ts
@@ -1,5 +1,5 @@
 import { accessClient } from 'api';
-import { Address, AddressParams } from 'model/shopInfo/address';
+import { Address, type AddressParams } from 'model/shopInfo/address';
 
 export const getAddress = async (params:AddressParams) => {
   const { data } = await accessClient.get<Address>('/address/search', { params });

--- a/src/model/shopInfo/address.ts
+++ b/src/model/shopInfo/address.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const AddressParams = z.object({
+  keyword: z.string(),
+  currentPage: z.string().default('1'),
+  countPerPage: z.string().default('10'),
+});
+
+export type AddressParams = z.infer<typeof AddressParams>;
+
+export const Juso = z.object({
+  bd_nm: z.string(),
+  emd_nm: z.string(),
+  eng_address: z.string(),
+  jibun_address: z.string(),
+  li_nm: z.string(),
+  rn: z.string(),
+  road_address: z.string(),
+  sgg_nm: z.string(),
+  si_nm: z.string(),
+  zip_no: z.string(),
+});
+
+export type Juso = z.infer<typeof Juso>;
+
+export const Address = z.object({
+  addresses: z.array(Juso),
+  count_per_page: z.number(),
+  current_page: z.number(),
+  total_count: z.string(),
+});
+
+export type Address = z.infer<typeof Address>;

--- a/src/model/shopInfo/address.ts
+++ b/src/model/shopInfo/address.ts
@@ -23,11 +23,11 @@ export const Juso = z.object({
 
 export type Juso = z.infer<typeof Juso>;
 
-export const Address = z.object({
+export const AddressSearchResponse = z.object({
   addresses: z.array(Juso),
   count_per_page: z.number(),
   current_page: z.number(),
   total_count: z.string(),
 });
 
-export type Address = z.infer<typeof Address>;
+export type AddressSearchResponse = z.infer<typeof AddressSearchResponse>;

--- a/src/model/shopInfo/ownerShop.ts
+++ b/src/model/shopInfo/ownerShop.ts
@@ -3,6 +3,7 @@ import { Shop } from './allShopInfo';
 
 export const OwnerShop = Shop.omit({ id: true }).extend({
   address: z.string(),
+  address_detail: z.string(),
   description: z.string(),
   delivery_price: z.number(),
   image_urls: z.array(z.string()),

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/AddressSearch.module.scss
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/AddressSearch.module.scss
@@ -1,0 +1,77 @@
+.address-search {
+  position: relative;
+  margin-top: 36px;
+  display: flex;
+  flex-direction: column;
+}
+
+.address-search__form {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #fff;
+  padding-bottom: 8px;
+}
+
+.address-search__input {
+  width: 380px;
+  border: 1px solid #d2dae2;
+  height: 22px;
+  padding: 13px 16px;
+
+  &:focus {
+    border-bottom: 1px solid black;
+  }
+}
+
+.address-search__result-list {
+  margin-top: 12px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.address-search__result-list-ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.address-search__result-list-item {
+  margin-bottom: 8px;
+}
+
+.address-search__result-list-button {
+  width: 100%;
+  text-align: left;
+  padding: 12px;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  background-color: #fff;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f9f9f9;
+  }
+}
+
+.address-search__result-list-empty {
+  padding: 16px;
+  font-size: 14px;
+  color: #888;
+}
+
+.address-search__result-title {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 160%;
+}
+
+.address-search__result-subtitle {
+  font-size: 12px;
+  line-height: 160%;
+  font-weight: 400;
+  color: #6b7280;
+}

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
-import CustomButton from 'page/Auth/Signup/CustomButton';
 import useAddress from 'query/address';
 import { Juso } from 'model/shopInfo/address';
+import CustomButton from 'page/Auth/Signup/CustomButton';
 import styles from './AddressSearch.module.scss';
 
 interface AddressSearchProps {
@@ -10,23 +9,16 @@ interface AddressSearchProps {
 }
 
 export default function AddressSearch({ onSelect, onClose }: AddressSearchProps) {
-  const [keywordInput, setKeywordInput] = useState('');
-  const [searchedKeyword, setSearchedKeyword] = useState('');
+  const {
+    address, changeAddress, search, addressData,
+  } = useAddress();
 
-  const { addressData } = useAddress(searchedKeyword);
-
-  const handleSearchClick = () => {
-    setSearchedKeyword(keywordInput);
-  };
+  const jusoList: Juso[] = addressData?.addresses ?? [];
 
   const handlePick = (addr: Juso) => {
     onSelect(addr);
-    if (onClose) {
-      onClose();
-    }
+    onClose?.();
   };
-
-  const jusoList: Juso[] = addressData?.addresses ?? [];
 
   return (
     <div className={styles['address-search']}>
@@ -34,53 +26,42 @@ export default function AddressSearch({ onSelect, onClose }: AddressSearchProps)
         className={styles['address-search__form']}
         onSubmit={(e) => {
           e.preventDefault();
-          handleSearchClick();
+          search();
         }}
       >
         <input
           className={styles['address-search__input']}
           placeholder="주소를 입력해주세요"
-          value={keywordInput}
-          onChange={(e) => setKeywordInput(e.target.value)}
+          value={address}
+          onChange={(e) => changeAddress(e.target.value)}
         />
-        <CustomButton
-          submit
-          content="검색"
-          buttonSize="small"
-        />
+        <CustomButton submit content="검색" buttonSize="small" />
       </form>
 
-      {searchedKeyword && (
+      {!!addressData && (
         <div className={styles['address-search__result-list']}>
           {jusoList.length > 0 ? (
             <ul className={styles['address-search__result-list-ul']}>
-              {jusoList.map((address) => {
-                const title = address.bd_nm === '' ? address.road_address : address.bd_nm;
-                const subtitle = address.road_address;
-                const key = `${address.zip_no}-${address.road_address}`;
+              {jusoList.map((a) => {
+                const title = a.bd_nm === '' ? a.road_address : a.bd_nm;
+                const subtitle = a.road_address;
+                const key = `${a.zip_no}-${a.road_address}`;
                 return (
                   <li key={key} className={styles['address-search__result-list-item']}>
                     <button
                       type="button"
                       className={styles['address-search__result-list-button']}
-                      onClick={() => handlePick(address)}
+                      onClick={() => handlePick(a)}
                     >
-                      <div className={styles['address-search__result-title']}>
-                        {title}
-                      </div>
-                      <div className={styles['address-search__result-subtitle']}>
-                        {subtitle}
-                      </div>
+                      <div className={styles['address-search__result-title']}>{title}</div>
+                      <div className={styles['address-search__result-subtitle']}>{subtitle}</div>
                     </button>
-
                   </li>
                 );
               })}
             </ul>
           ) : (
-            <div className={styles['address-search__result-list-empty']}>
-              검색 결과가 없습니다.
-            </div>
+            <div className={styles['address-search__result-list-empty']}>검색 결과가 없습니다.</div>
           )}
         </div>
       )}

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import useAddress from 'query/address';
-import { Juso } from 'model/shopInfo/address';
+import type { AddressSearchResponse, Juso } from 'model/shopInfo/address';
 import CustomButton from 'page/Auth/Signup/CustomButton';
 import styles from './AddressSearch.module.scss';
 
@@ -9,9 +10,8 @@ interface AddressSearchProps {
 }
 
 export default function AddressSearch({ onSelect, onClose }: AddressSearchProps) {
-  const {
-    address, changeAddress, search, addressData,
-  } = useAddress();
+  const { address, changeAddress, search } = useAddress();
+  const [addressData, setAddressData] = useState<AddressSearchResponse | null>(null);
 
   const jusoList: Juso[] = addressData?.addresses ?? [];
 
@@ -20,14 +20,17 @@ export default function AddressSearch({ onSelect, onClose }: AddressSearchProps)
     onClose?.();
   };
 
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    const data = await search();
+    setAddressData(data ?? null);
+  };
+
   return (
     <div className={styles['address-search']}>
       <form
         className={styles['address-search__form']}
-        onSubmit={(e) => {
-          e.preventDefault();
-          search();
-        }}
+        onSubmit={handleSubmit}
       >
         <input
           className={styles['address-search__input']}

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import CustomButton from 'page/Auth/Signup/CustomButton';
+import useAddress from 'query/address';
+import { Juso } from 'model/shopInfo/address';
+import styles from './AddressSearch.module.scss';
+
+interface AddressSearchProps {
+  onSelect: (address: Juso) => void;
+  onClose: () => void;
+}
+
+export default function AddressSearch({ onSelect, onClose }: AddressSearchProps) {
+  const [keywordInput, setKeywordInput] = useState('');
+  const [searchedKeyword, setSearchedKeyword] = useState('');
+
+  const { addressData } = useAddress(searchedKeyword);
+
+  const handleSearchClick = () => {
+    setSearchedKeyword(keywordInput);
+  };
+
+  const handlePick = (addr: Juso) => {
+    onSelect(addr);
+    onClose();
+  };
+
+  const addresses: Juso[] = addressData?.addresses ?? [];
+
+  return (
+    <div className={styles['address-search']}>
+      <div className={styles['address-search__form']}>
+        <input
+          className={styles['address-search__input']}
+          placeholder="주소를 입력해주세요"
+          value={keywordInput}
+          onChange={(e) => setKeywordInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearchClick()}
+        />
+        <CustomButton content="검색" buttonSize="small" onClick={handleSearchClick} />
+      </div>
+
+      {searchedKeyword && (
+        <div className={styles['address-search__result-list']}>
+          {addresses.length > 0 ? (
+            <ul className={styles['address-search__result-list-ul']}>
+              {addresses.map((address) => {
+                const title = address.bd_nm === '' ? address.road_address : address.bd_nm;
+                const subtitle = address.road_address;
+                const key = `${address.zip_no}-${address.road_address}`;
+                return (
+                  <li key={key} className={styles['address-search__result-list-item']}>
+                    <button
+                      type="button"
+                      className={styles['address-search__result-list-button']}
+                      onClick={() => handlePick(address)}
+                    >
+                      <div className={styles['address-search__result-title']}>
+                        {title}
+                      </div>
+                      <div className={styles['address-search__result-subtitle']}>
+                        {subtitle}
+                      </div>
+                    </button>
+
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <div className={styles['address-search__result-list-empty']}>
+              검색 결과가 없습니다.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
@@ -6,7 +6,7 @@ import styles from './AddressSearch.module.scss';
 
 interface AddressSearchProps {
   onSelect: (address: Juso) => void;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 export default function AddressSearch({ onSelect, onClose }: AddressSearchProps) {
@@ -21,7 +21,9 @@ export default function AddressSearch({ onSelect, onClose }: AddressSearchProps)
 
   const handlePick = (addr: Juso) => {
     onSelect(addr);
-    onClose();
+    if (onClose) {
+      onClose();
+    }
   };
 
   const addresses: Juso[] = addressData?.addresses ?? [];

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
@@ -26,7 +26,7 @@ export default function AddressSearch({ onSelect, onClose }: AddressSearchProps)
     }
   };
 
-  const addresses: Juso[] = addressData?.addresses ?? [];
+  const jusoList: Juso[] = addressData?.addresses ?? [];
 
   return (
     <div className={styles['address-search']}>
@@ -52,9 +52,9 @@ export default function AddressSearch({ onSelect, onClose }: AddressSearchProps)
 
       {searchedKeyword && (
         <div className={styles['address-search__result-list']}>
-          {addresses.length > 0 ? (
+          {jusoList.length > 0 ? (
             <ul className={styles['address-search__result-list-ul']}>
-              {addresses.map((address) => {
+              {jusoList.map((address) => {
                 const title = address.bd_nm === '' ? address.road_address : address.bd_nm;
                 const subtitle = address.road_address;
                 const key = `${address.zip_no}-${address.road_address}`;

--- a/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
+++ b/src/page/ShopRegistration/component/Modal/AddressSearch/index.tsx
@@ -30,16 +30,25 @@ export default function AddressSearch({ onSelect, onClose }: AddressSearchProps)
 
   return (
     <div className={styles['address-search']}>
-      <div className={styles['address-search__form']}>
+      <form
+        className={styles['address-search__form']}
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSearchClick();
+        }}
+      >
         <input
           className={styles['address-search__input']}
           placeholder="주소를 입력해주세요"
           value={keywordInput}
           onChange={(e) => setKeywordInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && handleSearchClick()}
         />
-        <CustomButton content="검색" buttonSize="small" onClick={handleSearchClick} />
-      </div>
+        <CustomButton
+          submit
+          content="검색"
+          buttonSize="small"
+        />
+      </form>
 
       {searchedKeyword && (
         <div className={styles['address-search__result-list']}>

--- a/src/page/ShopRegistration/view/Mobile/Main/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/Main/index.tsx
@@ -107,24 +107,6 @@ export default function Main({ onNext, onPrev }:{
       <div className={styles['form__error-message']}>
         {errors.name && <ErrorMessage message={ERRORMESSAGE.name} />}
       </div>
-      <label
-        htmlFor="shopAddress"
-        className={cn({
-          [styles.form__label]: true,
-          [styles['form__label--error']]: errors.address !== undefined,
-        })}
-      >
-        주소정보
-        <input
-          type="text"
-          id="shopAddress"
-          className={styles.form__input}
-          {...register('address', { required: true })}
-        />
-      </label>
-      <div className={styles['form__error-message']}>
-        {errors.address && <ErrorMessage message={ERRORMESSAGE.address} />}
-      </div>
       <div className={styles.form__footer}>
         <button
           className={styles.form__cancel}

--- a/src/page/ShopRegistration/view/Mobile/ShopAddress/ShopAddress.module.scss
+++ b/src/page/ShopRegistration/view/Mobile/ShopAddress/ShopAddress.module.scss
@@ -1,4 +1,3 @@
-/* AddressStep.module.scss */
 .step {
   display: flex;
   flex-direction: column;

--- a/src/page/ShopRegistration/view/Mobile/ShopAddress/ShopAddress.module.scss
+++ b/src/page/ShopRegistration/view/Mobile/ShopAddress/ShopAddress.module.scss
@@ -1,0 +1,76 @@
+/* AddressStep.module.scss */
+.step {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &__search { margin-bottom: 8px; }
+
+  &__label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__input {
+    border: 1px solid #d2dae2;
+    border-radius: 4px;
+    padding: 12px;
+  }
+
+  &__label--error .step__input {
+    border-color: #e11d48;
+  }
+
+  &__error {
+    min-height: 18px;
+    color: #e11d48;
+    font-size: 12px;
+  }
+
+  &__footer {
+    width: 100%;
+    height: 100px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__cancel {
+    display: flex;
+    width: 30%;
+    height: 44px;
+    padding: 4px 32px;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    border-radius: 8px;
+    border: 1px solid #cacaca;
+    background-color: #fff;
+    cursor: pointer;
+    color: #cacaca;
+  }
+
+  &__next {
+    display: flex;
+    width: 60%;
+    height: 44px;
+    padding: 4px 32px;
+    cursor: pointer;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    border-radius: 8px;
+    background: #175c8e;
+    color: #fff;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 160%;
+    border: none;
+
+    &--disable {
+      background-color: #cacaca;
+    }
+  }
+}

--- a/src/page/ShopRegistration/view/Mobile/ShopAddress/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/ShopAddress/index.tsx
@@ -1,0 +1,88 @@
+import ErrorMessage from 'component/common/ErrorMessage';
+import { ERRORMESSAGE } from 'page/ShopRegistration/constant/errorMessage';
+import AddressSearch from 'page/ShopRegistration/component/Modal/AddressSearch';
+import type { Juso } from 'model/shopInfo/address';
+import cn from 'utils/ts/className';
+import { useFormContext } from 'react-hook-form';
+import styles from './ShopAddress.module.scss';
+
+export default function AddressStep({ onNext, onPrev }:{
+  onNext: () => void; onPrev: () => void;
+}) {
+  const {
+    register, setValue, trigger, formState: { errors },
+  } = useFormContext();
+
+  const handleSelect = (addr: Juso) => {
+    const main = addr.road_address?.trim() ? addr.road_address : addr.jibun_address;
+    setValue('address', main, { shouldValidate: true, shouldDirty: true });
+    setValue('address_detail', '', { shouldValidate: true, shouldDirty: true });
+  };
+
+  const handleNextClick = async () => {
+    const isValid = await trigger(['address', 'address_detail']);
+    if (!isValid) return;
+    onNext();
+  };
+
+  return (
+    <div className={styles.step}>
+      <div className={styles.step__search}>
+        <AddressSearch onSelect={handleSelect} />
+      </div>
+      <label
+        htmlFor="shopAddress"
+        className={cn({
+          [styles.step__label]: true,
+          [styles['step__label--error']]: errors.address !== undefined,
+        })}
+      >
+        주소정보
+        <input
+          type="text"
+          id="shopAddress"
+          className={styles.step__input}
+          {...register('address', { required: true })}
+          readOnly
+        />
+      </label>
+      <div className={styles.step__error}>
+        {errors.address && <ErrorMessage message={ERRORMESSAGE.address} />}
+      </div>
+      <label
+        htmlFor="shopAddressDetail"
+        className={cn({
+          [styles.step__label]: true,
+          [styles['step__label--error']]: errors.address_detail !== undefined,
+        })}
+      >
+        상세주소
+        <input
+          type="text"
+          id="shopAddressDetail"
+          className={styles.step__input}
+          {...register('address_detail', { required: true })}
+          placeholder="동/호수, 건물 내 위치 등"
+        />
+      </label>
+      <div className={styles.step__footer}>
+        <button
+          className={styles.step__cancel}
+          type="button"
+          onClick={onPrev}
+        >
+          취소
+        </button>
+        <button
+          className={cn({
+            [styles.step__next]: true,
+          })}
+          type="button"
+          onClick={handleNextClick}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/page/ShopRegistration/view/Mobile/ShopAddress/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/ShopAddress/index.tsx
@@ -6,9 +6,12 @@ import cn from 'utils/ts/className';
 import { useFormContext } from 'react-hook-form';
 import styles from './ShopAddress.module.scss';
 
-export default function AddressStep({ onNext, onPrev }:{
-  onNext: () => void; onPrev: () => void;
-}) {
+interface AddressSearchProps {
+  onNext: () => void,
+  onPrev: () => void
+}
+
+export default function AddressStep({ onNext, onPrev } : AddressSearchProps) {
   const {
     register, setValue, trigger, formState: { errors },
   } = useFormContext();

--- a/src/page/ShopRegistration/view/Mobile/ShopConfirmation/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/ShopConfirmation/index.tsx
@@ -47,7 +47,9 @@ export default function ShopConfirmation({ onNext, onPrev }:{
   )?.name;
   const mutation = usePostData({ onNext });
   const onSubmit: SubmitHandler<OwnerShop> = (data) => {
-    mutation.mutate(data);
+    const fullAddress = [data.address, data.address_detail].filter(Boolean).join(' ').trim();
+    const payload = { ...data, address: fullAddress };
+    mutation.mutate(payload);
   };
 
   return (

--- a/src/page/ShopRegistration/view/Mobile/index.tsx
+++ b/src/page/ShopRegistration/view/Mobile/index.tsx
@@ -12,6 +12,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import useStepStore from 'store/useStepStore';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { registerdStore } from 'api/auth';
+import ShopAddress from 'page/ShopRegistration/view/Mobile/ShopAddress';
 import styles from './ShopRegistrationMobile.module.scss';
 
 const OPEN_DEFAULT_VALUES = [
@@ -72,6 +73,7 @@ export default function ShopRegistrationMobile() {
       name: data.shop_name || '',
       phone: data.shop_number.replace(/^(\d{3})(\d{3,4})(\d{4})$/, '$1-$2-$3') || '',
       address: '',
+      address_detail: '',
       delivery: false,
       pay_bank: false,
       pay_card: false,
@@ -122,6 +124,22 @@ export default function ShopRegistrationMobile() {
             topTitle=""
             bottomTitle=""
             topText="등록 하시려는 업체의"
+            bottomText="주소 정보를 입력해 주세요."
+          />
+          <ProgressBar
+            step={PROGRESS_TITLE[3].step}
+            total={PROGRESS_TITLE.length}
+            progressTitle={PROGRESS_TITLE[3].title}
+          />
+          <ShopAddress onNext={() => setStep(4)} onPrev={decreaseStep} />
+        </>
+        )}
+        {step === 4 && (
+        <>
+          <SubTitle
+            topTitle=""
+            bottomTitle=""
+            topText="등록 하시려는 업체의"
             bottomText="세부 정보를 입력해 주세요."
           />
           <ProgressBar
@@ -129,10 +147,10 @@ export default function ShopRegistrationMobile() {
             total={PROGRESS_TITLE.length}
             progressTitle={PROGRESS_TITLE[3].title}
           />
-          <Sub onNext={() => setStep(4)} onPrev={decreaseStep} />
+          <Sub onNext={() => setStep(5)} onPrev={decreaseStep} />
         </>
         )}
-        {step === 4 && (
+        {step === 5 && (
         <>
           <SubTitle
             topTitle=""
@@ -146,11 +164,11 @@ export default function ShopRegistrationMobile() {
             total={PROGRESS_TITLE.length}
             progressTitle={PROGRESS_TITLE[4].title}
           />
-          <ShopConfirmation onNext={() => setStep(5)} onPrev={decreaseStep} />
+          <ShopConfirmation onNext={() => setStep(6)} onPrev={decreaseStep} />
 
         </>
         )}
-        {step === 5 && (
+        {step === 6 && (
         <ShopRegistrationComplete
           title="가게 등록 완료"
           topText="가게 등록이 완료되었습니다."

--- a/src/page/ShopRegistration/view/PC/ShopConfirmation/index.tsx
+++ b/src/page/ShopRegistration/view/PC/ShopConfirmation/index.tsx
@@ -20,6 +20,8 @@ import { useEffect } from 'react';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import useStoreTimeSetUp from 'page/ShopRegistration/hooks/useStoreTimeSetUp';
 import CustomButton from 'page/Auth/Signup/CustomButton';
+import AddressSearch from 'page/ShopRegistration/component/Modal/AddressSearch';
+import { Juso } from 'model/shopInfo/address';
 import styles from './ShopConfirmation.module.scss';
 
 export default function ShopConfirmation({ onNext }:{ onNext: () => void }) {
@@ -37,6 +39,11 @@ export default function ShopConfirmation({ onNext }:{ onNext: () => void }) {
     value: showConfirmPopup,
     setTrue: openConfirmPopup,
     setFalse: closeConfirmPopup,
+  } = useBooleanState(false);
+  const {
+    value: showAddressSearch,
+    setTrue: openAddressSearch,
+    setFalse: closeAddressSearch,
   } = useBooleanState(false);
 
   const {
@@ -76,7 +83,7 @@ export default function ShopConfirmation({ onNext }:{ onNext: () => void }) {
   };
 
   const handleNextClick = async () => {
-    const isValid = await trigger(['image_urls', 'name', 'phone', 'address']);
+    const isValid = await trigger(['image_urls', 'name', 'phone', 'address', 'address_detail']);
     if (isValid) {
       openConfirmPopup();
     }
@@ -85,6 +92,16 @@ export default function ShopConfirmation({ onNext }:{ onNext: () => void }) {
   const handleDeleteImage = (e: React.MouseEvent<HTMLDivElement>, imageUrl: string) => {
     e.preventDefault();
     setImageFile(imageFile.filter((img) => img !== imageUrl));
+  };
+
+  const handleAddressSelect = (address: Juso) => {
+    const main = address.road_address && address.road_address.trim() !== ''
+      ? address.road_address
+      : address.jibun_address;
+
+    setValue('address', main, { shouldValidate: true, shouldDirty: true });
+    setValue('address_detail', '', { shouldValidate: true, shouldDirty: true });
+    closeAddressSearch();
   };
 
   useEffect(() => {
@@ -96,7 +113,13 @@ export default function ShopConfirmation({ onNext }:{ onNext: () => void }) {
   const mutation = usePostData({ onNext });
 
   const onSubmit: SubmitHandler<OwnerShop> = (data) => {
-    mutation.mutate(data);
+    const fullAddress = [data.address, data.address_detail].filter(Boolean).join(' ').trim();
+
+    const payload = {
+      ...data,
+      address: fullAddress,
+    };
+    mutation.mutate(payload);
   };
 
   return (
@@ -193,11 +216,34 @@ export default function ShopConfirmation({ onNext }:{ onNext: () => void }) {
             <div className={styles.form__section}>
               <input
                 type="text"
-                className={styles['form__input-large']}
+                className={styles.form__input}
                 {...register('address', { required: true })}
+                readOnly
               />
+              <CustomButton content="주소 검색" buttonSize="small" onClick={openAddressSearch} />
             </div>
             {errors.address && <ErrorMessage message={ERRORMESSAGE.address} />}
+          </div>
+          <CustomModal
+            buttonText="다음"
+            title="주소 검색"
+            modalSize="extra-large"
+            hasFooter={false}
+            isOverflowVisible={false}
+            isOpen={showAddressSearch}
+            onCancel={closeAddressSearch}
+          >
+            <AddressSearch onSelect={handleAddressSelect} onClose={closeAddressSearch} />
+          </CustomModal>
+          <div>
+            <span className={styles.form__title}>상세주소</span>
+            <div className={styles.form__section}>
+              <input
+                type="text"
+                className={styles['form__input-large']}
+                {...register('address_detail', { required: true })}
+              />
+            </div>
           </div>
           <div>
             <span className={styles.form__title}>전화번호</span>

--- a/src/query/KeyFactory/addressKeys.ts
+++ b/src/query/KeyFactory/addressKeys.ts
@@ -1,0 +1,4 @@
+export const addressKeys = {
+  all: ['address'] as const,
+  search: (keyword: string) => [...addressKeys.all, 'search', keyword] as const,
+};

--- a/src/query/address.ts
+++ b/src/query/address.ts
@@ -1,27 +1,24 @@
 import { useState } from 'react';
 import { getAddress } from 'api/address';
-import type { AddressSearchResponse } from 'model/shopInfo/address';
 
 export default function useAddress() {
   const [address, setAddress] = useState('');
-  const [addressData, setAddressData] = useState<AddressSearchResponse | undefined>(undefined);
 
   const changeAddress = (keyword: string) => setAddress(keyword);
 
   const search = async () => {
-    if (!address.trim()) return;
-    const data = await getAddress({
+    if (!address.trim()) return null;
+
+    return getAddress({
       keyword: address,
       currentPage: '1',
       countPerPage: '10',
     });
-    setAddressData(data);
   };
 
   return {
     address,
     changeAddress,
     search,
-    addressData,
   };
 }

--- a/src/query/address.ts
+++ b/src/query/address.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getAddress } from 'api/address';
-import { Address } from 'model/shopInfo/address';
+import { AddressSearchResponse } from 'model/shopInfo/address';
 import { addressKeys } from './KeyFactory/addressKeys';
 
 const useAddress = (keyword: string) => {
-  const { data: addressData } = useQuery<Address>({
+  const { data: addressData } = useQuery<AddressSearchResponse>({
     queryKey: addressKeys.search(keyword),
     queryFn: () => getAddress({ keyword, currentPage: '1', countPerPage: '10' }),
     enabled: keyword.length > 0,

--- a/src/query/address.ts
+++ b/src/query/address.ts
@@ -1,16 +1,27 @@
-import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { getAddress } from 'api/address';
-import { AddressSearchResponse } from 'model/shopInfo/address';
-import { addressKeys } from './KeyFactory/addressKeys';
+import type { AddressSearchResponse } from 'model/shopInfo/address';
 
-const useAddress = (keyword: string) => {
-  const { data: addressData } = useQuery<AddressSearchResponse>({
-    queryKey: addressKeys.search(keyword),
-    queryFn: () => getAddress({ keyword, currentPage: '1', countPerPage: '10' }),
-    enabled: keyword.length > 0,
-  });
+export default function useAddress() {
+  const [address, setAddress] = useState('');
+  const [addressData, setAddressData] = useState<AddressSearchResponse | undefined>(undefined);
 
-  return { addressData };
-};
+  const changeAddress = (keyword: string) => setAddress(keyword);
 
-export default useAddress;
+  const search = async () => {
+    if (!address.trim()) return;
+    const data = await getAddress({
+      keyword: address,
+      currentPage: '1',
+      countPerPage: '10',
+    });
+    setAddressData(data);
+  };
+
+  return {
+    address,
+    changeAddress,
+    search,
+    addressData,
+  };
+}

--- a/src/query/address.ts
+++ b/src/query/address.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAddress } from 'api/address';
+import { Address } from 'model/shopInfo/address';
+import { addressKeys } from './KeyFactory/addressKeys';
+
+const useAddress = (keyword: string) => {
+  const { data: addressData } = useQuery<Address>({
+    queryKey: addressKeys.search(keyword),
+    queryFn: () => getAddress({ keyword, currentPage: '1', countPerPage: '10' }),
+    enabled: keyword.length > 0,
+  });
+
+  return { addressData };
+};
+
+export default useAddress;


### PR DESCRIPTION
- Close #397
  
## What is this PR? 🔍

- 기능 : 주소 검증 추가 및 상세 주소 필드 분리
- issue : #397

## Changes 📝

기존 주소를 문자열로 바로 입력하던 방식에서 외부 API(행정안전부)를 백엔드를 통해 사용해서 검증된 주소를 입력하도록 수정했습니다.
이후 상세 주소를 별도 input으로 입력받도록 분리하였습니다.

## ScreenShot 📷

<img width="798" height="2888" alt="image" src="https://github.com/user-attachments/assets/6cdd70ed-37aa-4487-a415-40b4f56d6160" />
<img width="947" height="853" alt="스크린샷 2025-09-05 오후 4 44 19" src="https://github.com/user-attachments/assets/d2810007-5dc8-436c-844e-e37e85ea501d" />
<img width="535" height="867" alt="스크린샷 2025-09-05 오후 4 44 05" src="https://github.com/user-attachments/assets/cd792a69-38e3-4e35-a57b-a5ee24fcdf67" />

## Precaution
스프린트 회의에서 백엔드 수정 여부와 관계없이 프론트에서 미리 필드 분리와 검증 작업을 진행하기로 결정되었습니다.
따라서 현재 API에서는 아직 상세주소를 별도로 받지 않고 있어, 임시로 다시 하나의 address로 합쳐 전달하도록 처리했습니다.
UI 부분 역시 추후 사장님 웹·앱 개편 시 대규모 수정이 예정되어 있어, 현재는 임의로 구현해둔 상태입니다. 해당 내용은 사장님 스프린트가 진행될 때 함께 수정하도록 하겠습니다.

## ✔️ Please check if the PR fulfills these requirements

- [x] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [x] If on a hotfix branch, ensure it targets `main`?
- [x] There are no warning message when you run `yarn lint`
